### PR TITLE
feat: multiplayer backend host/bridge

### DIFF
--- a/poor_cli/multiplayer.py
+++ b/poor_cli/multiplayer.py
@@ -1,0 +1,550 @@
+"""Multiplayer WebSocket host runtime for poor-cli.
+
+This module hosts room-scoped JSON-RPC sessions over WebSocket. Each room has
+shared chat state, serialized prompt execution, role-based access control, and
+room lifecycle notifications.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import WSMsgType, web
+
+from .exceptions import setup_logger
+
+logger = setup_logger(__name__)
+
+
+@dataclass
+class InviteToken:
+    """Room-scoped invite token."""
+
+    token: str
+    role: str  # viewer | prompter
+
+
+@dataclass
+class ConnectionState:
+    """Connected websocket client state."""
+
+    connection_id: str
+    ws: web.WebSocketResponse
+    role: Optional[str] = None
+    room_name: Optional[str] = None
+    initialized: bool = False
+    client_name: str = ""
+    inline_server: Any = None
+
+
+@dataclass
+class QueuedRequest:
+    """Queued request for room worker."""
+
+    connection_id: str
+    message: Any
+
+
+@dataclass
+class RoomState:
+    """Per-room runtime state."""
+
+    name: str
+    server: Any
+    tokens: Dict[str, InviteToken]
+    members: Dict[str, ConnectionState] = field(default_factory=dict)
+    request_queue: "asyncio.Queue[QueuedRequest]" = field(default_factory=asyncio.Queue)
+    worker_task: Optional[asyncio.Task] = None
+    dispatch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    initialized: bool = False
+    base_capabilities: Dict[str, Any] = field(default_factory=dict)
+    active_connection_id: Optional[str] = None
+
+
+class MultiplayerHost:
+    """WebSocket host for multiplayer poor-cli sessions."""
+
+    _QUEUE_METHODS = {
+        "chat",
+        "poor-cli/chat",
+        "poor-cli/chatStreaming",
+    }
+
+    _VIEWER_BLOCKED_METHODS = {
+        "chat",
+        "poor-cli/chat",
+        "poor-cli/chatStreaming",
+        "poor-cli/inlineComplete",
+        "poor-cli/executeCommand",
+        "poor-cli/applyEdit",
+        "poor-cli/setConfig",
+        "poor-cli/toggleConfig",
+        "setConfig",
+        "switchProvider",
+        "poor-cli/switchProvider",
+        "poor-cli/cancelRequest",
+        "shutdown",
+    }
+
+    def __init__(
+        self,
+        *,
+        bind_host: str,
+        port: int,
+        room_names: List[str],
+        server_factory: Callable[[], Any],
+        message_cls: Any,
+        rpc_error_cls: Any,
+        default_permission_mode: str = "prompt",
+    ):
+        self.bind_host = bind_host
+        self.port = port
+        self.server_factory = server_factory
+        self.message_cls = message_cls
+        self.rpc_error_cls = rpc_error_cls
+        self.default_permission_mode = default_permission_mode
+
+        self.rooms: Dict[str, RoomState] = {}
+        self.connections: Dict[str, ConnectionState] = {}
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        self._app: Optional[web.Application] = None
+        self._stopped = False
+
+        normalized_rooms = [name.strip() for name in room_names if name and name.strip()]
+        if not normalized_rooms:
+            normalized_rooms = ["default"]
+
+        for room_name in normalized_rooms:
+            self.rooms[room_name] = self._create_room(room_name)
+
+    def _create_room(self, room_name: str) -> RoomState:
+        server = self.server_factory()
+        server.permission_mode = self.default_permission_mode
+
+        tokens = {
+            "viewer": InviteToken(token=secrets.token_urlsafe(18), role="viewer"),
+            "prompter": InviteToken(token=secrets.token_urlsafe(18), role="prompter"),
+        }
+        token_index = {token.token: token for token in tokens.values()}
+
+        room = RoomState(name=room_name, server=server, tokens=token_index)
+
+        async def _room_notification_sink(message: Any) -> None:
+            await self._broadcast_rpc(room, message)
+
+        # Monkeypatch sink for streaming notifications from PoorCLIServer.
+        room.server.write_message_stdio = _room_notification_sink  # type: ignore[attr-defined]
+        room.worker_task = asyncio.create_task(
+            self._room_worker(room), name=f"poor-cli-room-worker-{room_name}"
+        )
+        return room
+
+    def get_room_tokens(self) -> Dict[str, Dict[str, str]]:
+        """Return room->role->token mapping for host-local sharing."""
+        output: Dict[str, Dict[str, str]] = {}
+        for room_name, room in self.rooms.items():
+            role_map: Dict[str, str] = {}
+            for invite in room.tokens.values():
+                role_map[invite.role] = invite.token
+            output[room_name] = role_map
+        return output
+
+    async def start(self) -> None:
+        """Start the HTTP/WebSocket host."""
+        app = web.Application()
+        app.router.add_get("/rpc", self._handle_ws)
+        app.router.add_get("/health", self._handle_health)
+
+        self._app = app
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, host=self.bind_host, port=self.port)
+        await self._site.start()
+        logger.info("Multiplayer host listening on ws://%s:%s/rpc", self.bind_host, self.port)
+
+    async def stop(self) -> None:
+        """Stop host and workers."""
+        if self._stopped:
+            return
+        self._stopped = True
+
+        for room in self.rooms.values():
+            if room.worker_task:
+                room.worker_task.cancel()
+
+        for room in self.rooms.values():
+            if room.worker_task:
+                try:
+                    await room.worker_task
+                except asyncio.CancelledError:
+                    pass
+
+        for conn in list(self.connections.values()):
+            try:
+                await conn.ws.close()
+            except Exception:
+                pass
+
+        if self._runner:
+            await self._runner.cleanup()
+
+    async def run_forever(self) -> None:
+        """Run host until interrupted."""
+        await self.start()
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        finally:
+            await self.stop()
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        del request
+        return web.json_response(
+            {
+                "ok": True,
+                "rooms": sorted(self.rooms.keys()),
+                "connections": len(self.connections),
+            }
+        )
+
+    async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse(heartbeat=30)
+        await ws.prepare(request)
+
+        conn = ConnectionState(connection_id=uuid.uuid4().hex[:12], ws=ws)
+        self.connections[conn.connection_id] = conn
+
+        try:
+            async for incoming in ws:
+                if incoming.type != WSMsgType.TEXT:
+                    if incoming.type in {WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED}:
+                        break
+                    continue
+
+                try:
+                    payload = json.loads(incoming.data)
+                except json.JSONDecodeError:
+                    await self._send_error_response(
+                        ws,
+                        request_id=None,
+                        code=self.rpc_error_cls.PARSE_ERROR,
+                        message="Invalid JSON",
+                        data={"error_code": "PARSE_ERROR"},
+                    )
+                    continue
+
+                if not isinstance(payload, dict):
+                    await self._send_error_response(
+                        ws,
+                        request_id=None,
+                        code=self.rpc_error_cls.INVALID_REQUEST,
+                        message="JSON-RPC payload must be an object",
+                        data={"error_code": "INVALID_REQUEST"},
+                    )
+                    continue
+
+                message = self.message_cls.from_dict(payload)
+                await self._handle_message(conn, message)
+
+        finally:
+            await self._cleanup_connection(conn)
+
+        return ws
+
+    async def _handle_message(self, conn: ConnectionState, message: Any) -> None:
+        if not conn.initialized:
+            if message.method != "initialize":
+                await self._send_error_response(
+                    conn.ws,
+                    request_id=message.id,
+                    code=self.rpc_error_cls.INVALID_REQUEST,
+                    message="Connection not initialized. Call initialize with room and inviteToken.",
+                    data={"error_code": "NOT_INITIALIZED"},
+                )
+                return
+
+            await self._handle_initialize(conn, message)
+            return
+
+        if conn.room_name is None:
+            await self._send_error_response(
+                conn.ws,
+                request_id=message.id,
+                code=self.rpc_error_cls.INTERNAL_ERROR,
+                message="Initialized connection has no room",
+                data={"error_code": "ROOM_MISSING"},
+            )
+            return
+
+        room = self.rooms.get(conn.room_name)
+        if room is None:
+            await self._send_error_response(
+                conn.ws,
+                request_id=message.id,
+                code=self.rpc_error_cls.INVALID_REQUEST,
+                message=f"Unknown room: {conn.room_name}",
+                data={"error_code": "ROOM_NOT_FOUND"},
+            )
+            return
+
+        method = message.method or ""
+
+        if method == "poor-cli/permissionRes":
+            if conn.role != "prompter":
+                await self._send_error_response(
+                    conn.ws,
+                    request_id=message.id,
+                    code=self.rpc_error_cls.INTERNAL_ERROR,
+                    message="Only prompter role can answer permission prompts",
+                    data={"error_code": "permission_denied", "role": conn.role},
+                )
+                return
+            await room.server._handle_notification(message)
+            return
+
+        if conn.role == "viewer" and method in self._VIEWER_BLOCKED_METHODS:
+            await self._send_error_response(
+                conn.ws,
+                request_id=message.id,
+                code=self.rpc_error_cls.INTERNAL_ERROR,
+                message=f"Method not allowed for viewer role: {method}",
+                data={"error_code": "permission_denied", "role": conn.role, "method": method},
+            )
+            return
+
+        if method == "poor-cli/cancelRequest" and room.active_connection_id not in {
+            None,
+            conn.connection_id,
+        }:
+            await self._send_error_response(
+                conn.ws,
+                request_id=message.id,
+                code=self.rpc_error_cls.INTERNAL_ERROR,
+                message="Only active requester can cancel the in-flight request",
+                data={
+                    "error_code": "permission_denied",
+                    "role": conn.role,
+                    "method": method,
+                },
+            )
+            return
+
+        if method == "poor-cli/inlineComplete":
+            response = await self._dispatch_inline_isolated(conn, room, message)
+            if message.id is not None:
+                await self._send_rpc(conn.ws, response)
+            return
+
+        if method in self._QUEUE_METHODS:
+            await room.request_queue.put(QueuedRequest(connection_id=conn.connection_id, message=message))
+            await self._broadcast_room_event(
+                room,
+                "queued",
+                request_id=self._extract_request_id(message),
+                actor=conn.connection_id,
+                queue_depth=room.request_queue.qsize(),
+            )
+            return
+
+        async with room.dispatch_lock:
+            response = await room.server.dispatch(message)
+        if message.id is not None:
+            await self._send_rpc(conn.ws, response)
+
+    async def _dispatch_inline_isolated(self, conn: ConnectionState, room: RoomState, message: Any) -> Any:
+        if conn.inline_server is None:
+            conn.inline_server = self.server_factory()
+            provider_info = {}
+            room_core = getattr(room.server, "core", None)
+            if room_core is not None and getattr(room.server, "initialized", False):
+                provider_info = room.server.core.get_provider_info()
+            init_params: Dict[str, Any] = {
+                "provider": provider_info.get("name"),
+                "model": provider_info.get("model"),
+            }
+            init_params = {k: v for k, v in init_params.items() if v}
+            await conn.inline_server.handle_initialize(init_params)
+
+            # Disable persistence for isolated inline engine.
+            inline_core = getattr(conn.inline_server, "core", None)
+            if inline_core is not None:
+                inline_core.history_adapter = None
+
+        response = await conn.inline_server.dispatch(message)
+        return response
+
+    async def _handle_initialize(self, conn: ConnectionState, message: Any) -> None:
+        params = message.params or {}
+        room_name = str(params.get("room", "")).strip()
+        invite_token = str(params.get("inviteToken", "")).strip()
+        client_name = str(params.get("clientName", "")).strip()
+
+        room = self.rooms.get(room_name)
+        invite = room.tokens.get(invite_token) if room else None
+
+        if room is None or invite is None:
+            await self._send_error_response(
+                conn.ws,
+                request_id=message.id,
+                code=self.rpc_error_cls.INVALID_PARAMS,
+                message="Invalid room or inviteToken",
+                data={"error_code": "INVALID_MULTIPLAYER_AUTH"},
+            )
+            return
+
+        conn.role = invite.role
+        conn.room_name = room_name
+        conn.client_name = client_name
+
+        if not room.initialized:
+            init_params = dict(params)
+            init_params.pop("room", None)
+            init_params.pop("inviteToken", None)
+            init_params.pop("clientName", None)
+            result = await room.server.handle_initialize(init_params)
+            room.initialized = True
+            room.base_capabilities = dict(result.get("capabilities", {}))
+
+        conn.initialized = True
+        room.members[conn.connection_id] = conn
+
+        capabilities = dict(room.base_capabilities)
+        capabilities["multiplayer"] = {
+            "enabled": True,
+            "room": room_name,
+            "role": conn.role,
+            "queueMode": "serialized",
+        }
+
+        response = self.message_cls(id=message.id, result={"capabilities": capabilities})
+        await self._send_rpc(conn.ws, response)
+
+        await self._broadcast_room_event(
+            room,
+            "member_joined",
+            actor=conn.connection_id,
+            queue_depth=room.request_queue.qsize(),
+        )
+
+    async def _room_worker(self, room: RoomState) -> None:
+        while True:
+            queued = await room.request_queue.get()
+
+            conn = room.members.get(queued.connection_id)
+            if conn is None or conn.ws.closed:
+                continue
+
+            room.active_connection_id = queued.connection_id
+            request_id = self._extract_request_id(queued.message)
+
+            await self._broadcast_room_event(
+                room,
+                "started",
+                request_id=request_id,
+                actor=queued.connection_id,
+                queue_depth=room.request_queue.qsize(),
+            )
+
+            try:
+                async with room.dispatch_lock:
+                    response = await room.server.dispatch(queued.message)
+                if queued.message.id is not None:
+                    await self._send_rpc(conn.ws, response)
+            except Exception as e:
+                logger.exception("Room worker dispatch failed for room %s", room.name)
+                if queued.message.id is not None:
+                    await self._send_error_response(
+                        conn.ws,
+                        request_id=queued.message.id,
+                        code=self.rpc_error_cls.INTERNAL_ERROR,
+                        message=str(e),
+                        data={"error_code": "INTERNAL_ERROR"},
+                    )
+            finally:
+                room.active_connection_id = None
+                await self._broadcast_room_event(
+                    room,
+                    "finished",
+                    request_id=request_id,
+                    actor=queued.connection_id,
+                    queue_depth=room.request_queue.qsize(),
+                )
+
+    async def _cleanup_connection(self, conn: ConnectionState) -> None:
+        self.connections.pop(conn.connection_id, None)
+
+        if conn.room_name:
+            room = self.rooms.get(conn.room_name)
+            if room and conn.connection_id in room.members:
+                room.members.pop(conn.connection_id, None)
+                await self._broadcast_room_event(
+                    room,
+                    "member_left",
+                    actor=conn.connection_id,
+                    queue_depth=room.request_queue.qsize(),
+                )
+
+    async def _broadcast_rpc(self, room: RoomState, message: Any) -> None:
+        dead_members: List[str] = []
+        for connection_id, member in room.members.items():
+            if member.ws.closed:
+                dead_members.append(connection_id)
+                continue
+            try:
+                await self._send_rpc(member.ws, message)
+            except Exception:
+                dead_members.append(connection_id)
+
+        for connection_id in dead_members:
+            room.members.pop(connection_id, None)
+            self.connections.pop(connection_id, None)
+
+    async def _broadcast_room_event(
+        self,
+        room: RoomState,
+        event_type: str,
+        request_id: str = "",
+        actor: str = "",
+        queue_depth: int = 0,
+    ) -> None:
+        notification = self.message_cls(
+            method="poor-cli/roomEvent",
+            params={
+                "eventType": event_type,
+                "room": room.name,
+                "requestId": request_id,
+                "actor": actor,
+                "queueDepth": queue_depth,
+            },
+        )
+        await self._broadcast_rpc(room, notification)
+
+    async def _send_rpc(self, ws: web.WebSocketResponse, message: Any) -> None:
+        await ws.send_str(message.to_json())
+
+    async def _send_error_response(
+        self,
+        ws: web.WebSocketResponse,
+        request_id: Any,
+        code: int,
+        message: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        response = self.message_cls(
+            id=request_id,
+            error=self.rpc_error_cls.make_error(code, message, data),
+        )
+        await self._send_rpc(ws, response)
+
+    @staticmethod
+    def _extract_request_id(message: Any) -> str:
+        if not message.params:
+            return ""
+        value = message.params.get("requestId", "")
+        return str(value)

--- a/poor_cli/server.py
+++ b/poor_cli/server.py
@@ -8,10 +8,12 @@ It supports stdio transport for Neovim integration.
 import argparse
 import ast
 import asyncio
+import contextlib
 import copy
 import difflib
 import json
 import logging
+import shutil
 import sys
 import uuid
 from dataclasses import dataclass, field
@@ -1668,10 +1670,264 @@ class StreamingJsonRpcServer(PoorCLIServer):
 # =============================================================================
 
 
+class NgrokTunnel:
+    """Helper for launching ngrok and extracting a public URL."""
+
+    def __init__(self, target_addr: str):
+        self.target_addr = target_addr
+        self.process: Optional[asyncio.subprocess.Process] = None
+        self.public_url: Optional[str] = None
+
+    async def start(self, timeout_seconds: float = 12.0) -> Optional[str]:
+        """Start ngrok and wait for a public HTTPS URL."""
+        if shutil.which("ngrok") is None:
+            logger.warning("ngrok not found in PATH; tunnel disabled")
+            return None
+
+        self.process = await asyncio.create_subprocess_exec(
+            "ngrok",
+            "http",
+            self.target_addr,
+            "--log=stdout",
+            "--log-format=json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        if self.process.stdout is None:
+            logger.warning("ngrok stdout unavailable; tunnel URL could not be determined")
+            return None
+
+        deadline = asyncio.get_event_loop().time() + timeout_seconds
+        while asyncio.get_event_loop().time() < deadline:
+            remaining = max(deadline - asyncio.get_event_loop().time(), 0.05)
+            try:
+                line = await asyncio.wait_for(self.process.stdout.readline(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+
+            if not line:
+                break
+
+            text = line.decode("utf-8", errors="ignore").strip()
+            if not text:
+                continue
+
+            url = None
+            try:
+                payload = json.loads(text)
+                if isinstance(payload, dict):
+                    url = payload.get("url")
+                    if not url:
+                        nested = payload.get("obj")
+                        if isinstance(nested, dict):
+                            url = nested.get("url")
+            except json.JSONDecodeError:
+                pass
+
+            if isinstance(url, str) and url.startswith("https://"):
+                self.public_url = url
+                logger.info(f"ngrok tunnel ready: {url}")
+                return url
+
+        logger.warning("Timed out waiting for ngrok public URL")
+        return None
+
+    async def stop(self) -> None:
+        """Terminate ngrok process if running."""
+        if self.process is None:
+            return
+
+        if self.process.returncode is None:
+            self.process.terminate()
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self.process.kill()
+                with contextlib.suppress(Exception):
+                    await self.process.wait()
+
+        self.process = None
+
+
+def _print_multiplayer_join_hints(
+    ws_url: str,
+    tokens: Dict[str, Dict[str, str]],
+) -> None:
+    """Print host-local room/token join instructions."""
+    print("\npoor-cli multiplayer host is ready.", file=sys.stderr)
+    print(f"WebSocket endpoint: {ws_url}", file=sys.stderr)
+    print("", file=sys.stderr)
+    for room_name in sorted(tokens.keys()):
+        viewer_token = tokens[room_name].get("viewer", "")
+        prompter_token = tokens[room_name].get("prompter", "")
+        print(f"Room: {room_name}", file=sys.stderr)
+        print(f"  viewer token:   {viewer_token}", file=sys.stderr)
+        print(f"  prompter token: {prompter_token}", file=sys.stderr)
+        print(
+            f"  TUI join: poor-cli --remote-url {ws_url} --remote-room {room_name} --remote-token {prompter_token}",
+            file=sys.stderr,
+        )
+        print(
+            f"  Neovim: multiplayer={{ enabled=true, url='{ws_url}', room='{room_name}', token='{prompter_token}' }}",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+
+
+async def _run_stdio_bridge(
+    url: str,
+    room: str,
+    token: str,
+) -> None:
+    """Run a stdio <-> WebSocket JSON-RPC bridge."""
+    try:
+        import aiohttp
+    except ImportError as e:
+        raise RuntimeError(
+            "Bridge mode requires aiohttp. Install dependencies with: pip install -r requirements.txt"
+        ) from e
+
+    io_server = PoorCLIServer()
+    logger.info(f"Starting stdio bridge to {url} (room={room})")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(url, heartbeat=30) as ws:
+            stdin_eof = asyncio.Event()
+
+            async def _ws_to_stdio() -> None:
+                async for message in ws:
+                    if message.type != aiohttp.WSMsgType.TEXT:
+                        if message.type in {
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED,
+                        }:
+                            break
+                        continue
+
+                    try:
+                        payload = json.loads(message.data)
+                    except json.JSONDecodeError:
+                        logger.warning("Bridge received non-JSON websocket payload")
+                        continue
+
+                    if not isinstance(payload, dict):
+                        logger.warning("Bridge received non-object websocket payload")
+                        continue
+
+                    rpc_msg = JsonRpcMessage.from_dict(payload)
+                    await io_server.write_message_stdio(rpc_msg)
+
+            async def _stdio_to_ws() -> None:
+                while True:
+                    rpc_msg = await io_server.read_message_stdio()
+                    if rpc_msg is None:
+                        stdin_eof.set()
+                        break
+
+                    if rpc_msg.method == "initialize":
+                        params = dict(rpc_msg.params or {})
+                        params.setdefault("room", room)
+                        params.setdefault("inviteToken", token)
+                        params.setdefault("clientName", "stdio-bridge")
+                        rpc_msg.params = params
+
+                    await ws.send_str(rpc_msg.to_json())
+
+            ws_reader = asyncio.create_task(_ws_to_stdio(), name="poor-cli-bridge-ws-reader")
+            stdio_reader = asyncio.create_task(_stdio_to_ws(), name="poor-cli-bridge-stdio-reader")
+
+            try:
+                await stdio_reader
+
+                # Drain in-flight websocket responses/notifications briefly before shutdown.
+                if stdin_eof.is_set():
+                    drain_deadline = asyncio.get_event_loop().time() + 0.25
+                    while not ws_reader.done() and asyncio.get_event_loop().time() < drain_deadline:
+                        await asyncio.sleep(0.01)
+                    await ws.close()
+
+                await ws_reader
+            finally:
+                for task in (stdio_reader, ws_reader):
+                    if not task.done():
+                        task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await task
+
+
+async def _run_multiplayer_host(
+    bind_host: str,
+    port: int,
+    rooms: List[str],
+    permission_mode: str,
+    enable_ngrok: bool,
+) -> None:
+    """Run multiplayer WebSocket host mode."""
+    from .multiplayer import MultiplayerHost
+
+    host = MultiplayerHost(
+        bind_host=bind_host,
+        port=port,
+        room_names=rooms,
+        server_factory=PoorCLIServer,
+        message_cls=JsonRpcMessage,
+        rpc_error_cls=JsonRpcError,
+        default_permission_mode=permission_mode,
+    )
+
+    tunnel: Optional[NgrokTunnel] = None
+    await host.start()
+    base_ws_url = f"ws://{bind_host}:{port}/rpc"
+    _print_multiplayer_join_hints(base_ws_url, host.get_room_tokens())
+
+    if enable_ngrok:
+        tunnel = NgrokTunnel(f"{bind_host}:{port}")
+        public_https = await tunnel.start()
+        if public_https:
+            public_ws = public_https.replace("https://", "wss://", 1) + "/rpc"
+            _print_multiplayer_join_hints(public_ws, host.get_room_tokens())
+        else:
+            logger.warning("ngrok helper failed; host is still running on local interface")
+
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    finally:
+        await host.stop()
+        if tunnel is not None:
+            await tunnel.stop()
+
+
 def main() -> None:
     """Main entry point for the server."""
     parser = argparse.ArgumentParser(description="PoorCLI JSON-RPC Server for editor integration")
     parser.add_argument("--stdio", action="store_true", help="Use stdio transport (for Neovim)")
+    parser.add_argument("--host", action="store_true", help="Run multiplayer WebSocket host mode")
+    parser.add_argument("--bind", default="127.0.0.1", help="Host bind address for --host mode")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Host port for --host mode (default: 8765)",
+    )
+    parser.add_argument(
+        "--room",
+        action="append",
+        default=[],
+        help="Multiplayer room name (repeatable in --host mode)",
+    )
+    parser.add_argument(
+        "--permission-mode",
+        default="prompt",
+        choices=[mode.value for mode in PermissionMode],
+        help="Default permission mode for multiplayer room engines",
+    )
+    parser.add_argument("--ngrok", action="store_true", help="Launch ngrok helper in --host mode")
+    parser.add_argument("--bridge", action="store_true", help="Run stdio <-> WebSocket bridge mode")
+    parser.add_argument("--url", help="WebSocket URL for --bridge mode (ws:// or wss://)")
+    parser.add_argument("--token", help="Invite token for --bridge mode")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
 
     args = parser.parse_args()
@@ -1684,9 +1940,34 @@ def main() -> None:
         stream=sys.stderr,  # Log to stderr to keep stdout clean for JSON-RPC
     )
 
-    server = PoorCLIServer()
+    if args.host and args.bridge:
+        raise SystemExit("Choose exactly one mode: either --host or --bridge (not both).")
 
-    # Stdio is the only supported transport.
+    if args.bridge:
+        if not args.url:
+            raise SystemExit("--bridge requires --url")
+        bridge_room = args.room[0] if args.room else ""
+        if not bridge_room:
+            raise SystemExit("--bridge requires --room <name>")
+        if not args.token:
+            raise SystemExit("--bridge requires --token")
+        asyncio.run(_run_stdio_bridge(args.url, bridge_room, args.token))
+        return
+
+    if args.host:
+        asyncio.run(
+            _run_multiplayer_host(
+                bind_host=args.bind,
+                port=args.port,
+                rooms=args.room,
+                permission_mode=args.permission_mode,
+                enable_ngrok=args.ngrok,
+            )
+        )
+        return
+
+    server = PoorCLIServer()
+    # Default mode remains stdio for backward compatibility.
     asyncio.run(server.run_stdio())
 
 

--- a/tests/test_multiplayer_bridge.py
+++ b/tests/test_multiplayer_bridge.py
@@ -1,0 +1,126 @@
+"""Tests for stdio <-> WebSocket bridge mode."""
+
+import asyncio
+import json
+import socket
+from collections import deque
+from typing import Deque, List
+
+import pytest
+aiohttp = pytest.importorskip("aiohttp")
+from aiohttp import web
+
+from poor_cli.server import JsonRpcMessage, _run_stdio_bridge
+
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+class _FakeStdioServer:
+    instances: List["_FakeStdioServer"] = []
+
+    def __init__(self):
+        self.read_queue: Deque[JsonRpcMessage] = deque(
+            [
+                JsonRpcMessage(
+                    id=1,
+                    method="initialize",
+                    params={"provider": "gemini", "streaming": True},
+                ),
+                JsonRpcMessage(
+                    id=2,
+                    method="poor-cli/getConfig",
+                    params={},
+                ),
+            ]
+        )
+        self.written: List[JsonRpcMessage] = []
+        _FakeStdioServer.instances.append(self)
+
+    async def read_message_stdio(self):
+        await asyncio.sleep(0)
+        if self.read_queue:
+            return self.read_queue.popleft()
+        return None
+
+    async def write_message_stdio(self, message: JsonRpcMessage):
+        self.written.append(message)
+
+
+@pytest.mark.asyncio
+async def test_bridge_injects_room_token_and_forwards_ws_messages(monkeypatch):
+    received_from_bridge: List[dict] = []
+
+    async def ws_handler(request: web.Request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                payload = json.loads(msg.data)
+                received_from_bridge.append(payload)
+
+                if payload.get("id") == 1:
+                    await ws.send_str(
+                        json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "method": "poor-cli/roomEvent",
+                                "params": {
+                                    "eventType": "member_joined",
+                                    "room": "dev",
+                                },
+                            }
+                        )
+                    )
+
+                await ws.send_str(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": payload.get("id"),
+                            "result": {"ok": True},
+                        }
+                    )
+                )
+
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/rpc", ws_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    port = _free_port()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+
+    monkeypatch.setattr("poor_cli.server.PoorCLIServer", _FakeStdioServer)
+
+    try:
+        await _run_stdio_bridge(
+            url=f"ws://127.0.0.1:{port}/rpc",
+            room="dev",
+            token="tok-123",
+        )
+
+        assert received_from_bridge, "bridge did not forward requests to websocket"
+        init_req = received_from_bridge[0]
+        assert init_req["method"] == "initialize"
+        assert init_req["params"]["room"] == "dev"
+        assert init_req["params"]["inviteToken"] == "tok-123"
+        assert init_req["params"]["clientName"] == "stdio-bridge"
+
+        fake_instance = _FakeStdioServer.instances[-1]
+        methods = [m.method for m in fake_instance.written]
+        assert "poor-cli/roomEvent" in methods
+        assert any(m.id == 1 and m.result == {"ok": True} for m in fake_instance.written)
+        assert any(m.id == 2 and m.result == {"ok": True} for m in fake_instance.written)
+    finally:
+        await runner.cleanup()

--- a/tests/test_multiplayer_host.py
+++ b/tests/test_multiplayer_host.py
@@ -1,0 +1,387 @@
+"""Tests for multiplayer WebSocket host runtime."""
+
+import asyncio
+import contextlib
+import json
+import socket
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import pytest
+aiohttp = pytest.importorskip("aiohttp")
+
+from poor_cli.multiplayer import MultiplayerHost
+from poor_cli.server import JsonRpcError, JsonRpcMessage
+
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+@dataclass
+class _FakeServer:
+    permission_mode: str = "prompt"
+    initialized: bool = False
+    dispatch_calls: List[str] = field(default_factory=list)
+    dispatch_request_ids: List[str] = field(default_factory=list)
+    notification_calls: List[JsonRpcMessage] = field(default_factory=list)
+    write_message_stdio: Any = None
+
+    async def handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        del params
+        self.initialized = True
+        return {
+            "capabilities": {
+                "completionProvider": True,
+                "inlineCompletionProvider": True,
+                "chatProvider": True,
+                "chatStreamingProvider": True,
+                "fileOperations": True,
+                "permissionMode": self.permission_mode,
+                "providerInfo": {"name": "fake", "model": "fake-model"},
+            }
+        }
+
+    async def dispatch(self, message: JsonRpcMessage) -> JsonRpcMessage:
+        method = message.method or ""
+        self.dispatch_calls.append(method)
+
+        if method == "poor-cli/chatStreaming":
+            request_id = str((message.params or {}).get("requestId", ""))
+            self.dispatch_request_ids.append(request_id)
+            if self.write_message_stdio is not None:
+                await self.write_message_stdio(
+                    JsonRpcMessage(
+                        method="poor-cli/streamChunk",
+                        params={"requestId": request_id, "chunk": "hello", "done": False},
+                    )
+                )
+                await self.write_message_stdio(
+                    JsonRpcMessage(
+                        method="poor-cli/streamChunk",
+                        params={"requestId": request_id, "chunk": "", "done": True},
+                    )
+                )
+            await asyncio.sleep(0.02)
+            return JsonRpcMessage(
+                id=message.id,
+                result={"content": "done", "role": "assistant"},
+            )
+
+        if method == "poor-cli/inlineComplete":
+            return JsonRpcMessage(id=message.id, result={"completion": "x", "isPartial": False})
+
+        return JsonRpcMessage(id=message.id, result={"ok": True, "method": method})
+
+    async def _handle_notification(self, message: JsonRpcMessage) -> None:
+        self.notification_calls.append(message)
+
+
+class _FakeServerFactory:
+    def __init__(self):
+        self.instances: List[_FakeServer] = []
+
+    def __call__(self) -> _FakeServer:
+        instance = _FakeServer()
+        self.instances.append(instance)
+        return instance
+
+
+async def _ws_recv_json(ws: aiohttp.ClientWebSocketResponse) -> Dict[str, Any]:
+    msg = await ws.receive(timeout=2.0)
+    assert msg.type == aiohttp.WSMsgType.TEXT
+    payload = json.loads(msg.data)
+    assert isinstance(payload, dict)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_initialize_auth_and_viewer_denied_prompt_methods():
+    factory = _FakeServerFactory()
+    port = _free_port()
+    host = MultiplayerHost(
+        bind_host="127.0.0.1",
+        port=port,
+        room_names=["dev"],
+        server_factory=factory,
+        message_cls=JsonRpcMessage,
+        rpc_error_cls=JsonRpcError,
+    )
+    await host.start()
+
+    tokens = host.get_room_tokens()["dev"]
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(f"ws://127.0.0.1:{port}/rpc") as ws:
+                await ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "room": "dev",
+                            "inviteToken": tokens["viewer"],
+                            "clientName": "viewer-a",
+                        },
+                    }
+                )
+                init_resp = await _ws_recv_json(ws)
+                assert init_resp["id"] == 1
+                assert init_resp["result"]["capabilities"]["multiplayer"]["role"] == "viewer"
+
+                # member_joined room event
+                room_event = await _ws_recv_json(ws)
+                assert room_event["method"] == "poor-cli/roomEvent"
+
+                await ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "poor-cli/chatStreaming",
+                        "params": {"message": "blocked", "requestId": "r1"},
+                    }
+                )
+                denied = await _ws_recv_json(ws)
+                assert denied["id"] == 2
+                assert denied["error"]["data"]["error_code"] == "permission_denied"
+
+            async with session.ws_connect(f"ws://127.0.0.1:{port}/rpc") as ws_bad:
+                await ws_bad.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "initialize",
+                        "params": {
+                            "room": "dev",
+                            "inviteToken": "invalid",
+                        },
+                    }
+                )
+                bad = await _ws_recv_json(ws_bad)
+                assert bad["id"] == 3
+                assert bad["error"]["code"] == JsonRpcError.INVALID_PARAMS
+
+    finally:
+        await host.stop()
+
+
+@pytest.mark.asyncio
+async def test_streaming_notifications_broadcast_but_response_only_to_requester():
+    factory = _FakeServerFactory()
+    port = _free_port()
+    host = MultiplayerHost(
+        bind_host="127.0.0.1",
+        port=port,
+        room_names=["dev"],
+        server_factory=factory,
+        message_cls=JsonRpcMessage,
+        rpc_error_cls=JsonRpcError,
+    )
+    await host.start()
+
+    tokens = host.get_room_tokens()["dev"]
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(f"ws://127.0.0.1:{port}/rpc") as prompter_ws, session.ws_connect(
+                f"ws://127.0.0.1:{port}/rpc"
+            ) as viewer_ws:
+                await prompter_ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {"room": "dev", "inviteToken": tokens["prompter"]},
+                    }
+                )
+                _ = await _ws_recv_json(prompter_ws)
+                _ = await _ws_recv_json(prompter_ws)
+
+                await viewer_ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "initialize",
+                        "params": {"room": "dev", "inviteToken": tokens["viewer"]},
+                    }
+                )
+                _ = await _ws_recv_json(viewer_ws)
+                _ = await _ws_recv_json(viewer_ws)
+                _ = await _ws_recv_json(prompter_ws)
+
+                await prompter_ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 99,
+                        "method": "poor-cli/chatStreaming",
+                        "params": {"message": "hello", "requestId": "req-99"},
+                    }
+                )
+
+                # both receive queue/started/stream events
+                seen_stream_prompter = False
+                seen_stream_viewer = False
+                got_final_response = False
+
+                for _ in range(8):
+                    payload = await _ws_recv_json(prompter_ws)
+                    if payload.get("method") == "poor-cli/streamChunk":
+                        seen_stream_prompter = True
+                    if payload.get("id") == 99:
+                        got_final_response = True
+                        break
+
+                for _ in range(6):
+                    payload = await _ws_recv_json(viewer_ws)
+                    if payload.get("method") == "poor-cli/streamChunk":
+                        seen_stream_viewer = True
+                        break
+
+                assert seen_stream_prompter
+                assert seen_stream_viewer
+                assert got_final_response
+
+                # Viewer should not receive requester's final RPC response id=99.
+                with contextlib.suppress(asyncio.TimeoutError):
+                    maybe_extra = await asyncio.wait_for(viewer_ws.receive(), timeout=0.1)
+                    if maybe_extra.type == aiohttp.WSMsgType.TEXT:
+                        payload = json.loads(maybe_extra.data)
+                        assert payload.get("id") != 99
+
+    finally:
+        await host.stop()
+
+
+@pytest.mark.asyncio
+async def test_same_room_queue_is_fifo():
+    factory = _FakeServerFactory()
+    port = _free_port()
+    host = MultiplayerHost(
+        bind_host="127.0.0.1",
+        port=port,
+        room_names=["dev"],
+        server_factory=factory,
+        message_cls=JsonRpcMessage,
+        rpc_error_cls=JsonRpcError,
+    )
+    await host.start()
+
+    tokens = host.get_room_tokens()["dev"]
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(f"ws://127.0.0.1:{port}/rpc") as ws1, session.ws_connect(
+                f"ws://127.0.0.1:{port}/rpc"
+            ) as ws2:
+                for ws in (ws1, ws2):
+                    await ws.send_json(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "initialize",
+                            "params": {"room": "dev", "inviteToken": tokens["prompter"]},
+                        }
+                    )
+                    _ = await _ws_recv_json(ws)
+                    _ = await _ws_recv_json(ws)
+
+                await ws1.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 10,
+                        "method": "poor-cli/chatStreaming",
+                        "params": {"message": "first", "requestId": "first"},
+                    }
+                )
+                await ws2.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 20,
+                        "method": "poor-cli/chatStreaming",
+                        "params": {"message": "second", "requestId": "second"},
+                    }
+                )
+
+                # drain responses/events from both sockets until both final responses observed
+                final_ids = set()
+                attempts = 0
+                while final_ids != {10, 20} and attempts < 30:
+                    attempts += 1
+                    payload1 = await _ws_recv_json(ws1)
+                    if payload1.get("id") in {10, 20}:
+                        final_ids.add(payload1["id"])
+                    payload2 = await _ws_recv_json(ws2)
+                    if payload2.get("id") in {10, 20}:
+                        final_ids.add(payload2["id"])
+
+                assert final_ids == {10, 20}
+                room_server = factory.instances[0]
+                chat_calls = [m for m in room_server.dispatch_calls if m == "poor-cli/chatStreaming"]
+                assert chat_calls == ["poor-cli/chatStreaming", "poor-cli/chatStreaming"]
+                assert room_server.dispatch_request_ids == ["first", "second"]
+
+    finally:
+        await host.stop()
+
+
+@pytest.mark.asyncio
+async def test_inline_complete_uses_isolated_engine_not_room_server():
+    factory = _FakeServerFactory()
+    port = _free_port()
+    host = MultiplayerHost(
+        bind_host="127.0.0.1",
+        port=port,
+        room_names=["dev"],
+        server_factory=factory,
+        message_cls=JsonRpcMessage,
+        rpc_error_cls=JsonRpcError,
+    )
+    await host.start()
+
+    tokens = host.get_room_tokens()["dev"]
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(f"ws://127.0.0.1:{port}/rpc") as ws:
+                await ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {"room": "dev", "inviteToken": tokens["prompter"]},
+                    }
+                )
+                _ = await _ws_recv_json(ws)
+                _ = await _ws_recv_json(ws)
+
+                await ws.send_json(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 77,
+                        "method": "poor-cli/inlineComplete",
+                        "params": {
+                            "codeBefore": "a",
+                            "codeAfter": "b",
+                            "instruction": "",
+                            "filePath": "x.py",
+                            "language": "python",
+                        },
+                    }
+                )
+
+                inline_resp = await _ws_recv_json(ws)
+                assert inline_resp["id"] == 77
+                assert inline_resp["result"]["completion"] == "x"
+
+                room_server = factory.instances[0]
+                assert "poor-cli/inlineComplete" not in room_server.dispatch_calls
+                assert len(factory.instances) >= 2  # room engine + isolated inline engine
+
+    finally:
+        await host.stop()


### PR DESCRIPTION
## Summary\n- add WebSocket multiplayer host runtime with room-scoped roles and tokens\n- add serialized room prompt queue + room lifecycle events\n- add stdio<->WebSocket bridge mode and ngrok helper support in server CLI\n- add backend multiplayer tests for host auth/roles, queueing, streaming broadcast, and bridge forwarding\n\n## Validation\n- .venv/bin/pytest tests/test_multiplayer_host.py tests/test_multiplayer_bridge.py tests/test_server.py tests/test_streaming_notifications.py