### PR TITLE
feat: TUI remote multiplayer bridge mode

### DIFF
--- a/poor-cli-tui/src/main.rs
+++ b/poor-cli-tui/src/main.rs
@@ -46,6 +46,15 @@ struct Cli {
     /// Python binary to use (default: python3)
     #[arg(long, default_value = "python3")]
     python: String,
+    /// Remote multiplayer websocket URL (bridge mode)
+    #[arg(long)]
+    remote_url: Option<String>,
+    /// Remote multiplayer room name (requires --remote-url and --remote-token)
+    #[arg(long)]
+    remote_room: Option<String>,
+    /// Remote multiplayer invite token (requires --remote-url and --remote-room)
+    #[arg(long)]
+    remote_token: Option<String>,
 }
 
 // ── Background message from server thread ────────────────────────────
@@ -162,10 +171,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+fn build_backend_server_args(cli: &Cli) -> Result<Vec<String>, String> {
+    match (&cli.remote_url, &cli.remote_room, &cli.remote_token) {
+        (None, None, None) => Ok(vec![]),
+        (Some(url), Some(room), Some(token)) => Ok(vec![
+            "--bridge".to_string(),
+            "--url".to_string(),
+            url.clone(),
+            "--room".to_string(),
+            room.clone(),
+            "--token".to_string(),
+            token.clone(),
+        ]),
+        _ => Err(
+            "Remote mode requires all of: --remote-url, --remote-room, --remote-token".to_string(),
+        ),
+    }
+}
+
 fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cli: Cli,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    let backend_server_args = build_backend_server_args(&cli)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
     let mut app = App::new();
     app.cwd = cli.cwd.clone().unwrap_or_else(|| {
         std::env::current_dir()
@@ -186,11 +216,13 @@ fn run_app(
     } else {
         cli.permission_mode.clone()
     };
+    let server_args = backend_server_args.clone();
 
     let tx_init = tx.clone();
     let tx_notif = tx.clone();
-    thread::spawn(
-        move || match RpcClient::spawn_with_notifications(&python_bin, cwd.as_deref()) {
+    thread::spawn(move || {
+        match RpcClient::spawn_with_notifications_args(&python_bin, cwd.as_deref(), &server_args)
+        {
             Ok((client, notification_rx)) => {
                 // Spawn notification reader thread → maps ServerNotification → ServerMsg
                 thread::spawn(move || loop {
@@ -316,8 +348,8 @@ fn run_app(
                     message: format!("Failed to start server: {e}"),
                 });
             }
-        },
-    );
+        }
+    });
 
     app.provider_name = cli.provider.unwrap_or_else(|| "gemini".into());
     app.model_name = cli.model.unwrap_or_else(|| "gemini-2.0-flash-exp".into());
@@ -3523,6 +3555,7 @@ fn format_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn create_temp_workspace(prefix: &str) -> PathBuf {
@@ -3539,6 +3572,46 @@ mod tests {
         let mut app = App::new();
         app.cwd = root.to_string_lossy().to_string();
         app
+    }
+
+    #[test]
+    fn backend_server_args_empty_for_local_mode() {
+        let cli = Cli::parse_from(["poor-cli-tui"]);
+        let args = build_backend_server_args(&cli).expect("local mode args should build");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn backend_server_args_for_remote_mode() {
+        let cli = Cli::parse_from([
+            "poor-cli-tui",
+            "--remote-url",
+            "wss://example.test/rpc",
+            "--remote-room",
+            "dev",
+            "--remote-token",
+            "tok-123",
+        ]);
+        let args = build_backend_server_args(&cli).expect("remote args should build");
+        assert_eq!(
+            args,
+            vec![
+                "--bridge".to_string(),
+                "--url".to_string(),
+                "wss://example.test/rpc".to_string(),
+                "--room".to_string(),
+                "dev".to_string(),
+                "--token".to_string(),
+                "tok-123".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn backend_server_args_require_complete_remote_triplet() {
+        let cli = Cli::parse_from(["poor-cli-tui", "--remote-url", "wss://example.test/rpc"]);
+        let err = build_backend_server_args(&cli).expect_err("should fail for partial remote args");
+        assert!(err.contains("--remote-url"));
     }
 
     #[test]

--- a/poor-cli-tui/src/rpc.rs
+++ b/poor-cli-tui/src/rpc.rs
@@ -386,15 +386,15 @@ fn parse_notification(method: &str, params: &Value) -> Option<ServerNotification
 }
 
 impl RpcClient {
-    /// Spawn the Python JSON-RPC server as a child process.
-    /// Returns the client and a notification receiver channel.
-    pub fn spawn_with_notifications(
+    fn build_server_command(
         python_bin: &str,
         cwd: Option<&str>,
-    ) -> Result<(Self, Receiver<ServerNotification>), String> {
+        server_args: &[String],
+    ) -> Command {
         let mut cmd = Command::new(python_bin);
         cmd.arg("-m")
             .arg("poor_cli.server")
+            .args(server_args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -403,7 +403,25 @@ impl RpcClient {
             cmd.current_dir(dir);
         }
 
-        let mut child = cmd
+        cmd
+    }
+
+    /// Spawn the Python JSON-RPC server as a child process.
+    /// Returns the client and a notification receiver channel.
+    pub fn spawn_with_notifications(
+        python_bin: &str,
+        cwd: Option<&str>,
+    ) -> Result<(Self, Receiver<ServerNotification>), String> {
+        Self::spawn_with_notifications_args(python_bin, cwd, &[])
+    }
+
+    /// Spawn the Python JSON-RPC server with extra command-line arguments.
+    pub fn spawn_with_notifications_args(
+        python_bin: &str,
+        cwd: Option<&str>,
+        server_args: &[String],
+    ) -> Result<(Self, Receiver<ServerNotification>), String> {
+        let mut child = Self::build_server_command(python_bin, cwd, server_args)
             .spawn()
             .map_err(|e| format!("Failed to start Python server: {e}"))?;
 
@@ -471,18 +489,7 @@ impl RpcClient {
 
     /// Legacy spawn without notifications (falls back to blocking call()).
     pub fn spawn(python_bin: &str, cwd: Option<&str>) -> Result<Self, String> {
-        let mut cmd = Command::new(python_bin);
-        cmd.arg("-m")
-            .arg("poor_cli.server")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        if let Some(dir) = cwd {
-            cmd.current_dir(dir);
-        }
-
-        let child = cmd
+        let child = Self::build_server_command(python_bin, cwd, &[])
             .spawn()
             .map_err(|e| format!("Failed to start Python server: {e}"))?;
 
@@ -1275,5 +1282,37 @@ mod tests {
         let cleaned = sanitize_rpc_error_message(&"x".repeat(800));
         assert!(cleaned.len() <= 360);
         assert!(cleaned.ends_with("..."));
+    }
+
+    #[test]
+    fn build_server_command_includes_extra_args() {
+        let args = vec![
+            "--bridge".to_string(),
+            "--url".to_string(),
+            "wss://example.test/rpc".to_string(),
+            "--room".to_string(),
+            "dev".to_string(),
+            "--token".to_string(),
+            "tok".to_string(),
+        ];
+        let cmd = RpcClient::build_server_command("python3", Some("/tmp"), &args);
+        let collected = cmd
+            .get_args()
+            .map(|v| v.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            collected,
+            vec![
+                "-m",
+                "poor_cli.server",
+                "--bridge",
+                "--url",
+                "wss://example.test/rpc",
+                "--room",
+                "dev",
+                "--token",
+                "tok",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary\n- add TUI remote flags: --remote-url, --remote-room, --remote-token\n- wire backend launch to bridge mode when remote flags are set\n- extend Rust RPC process launcher to pass server args\n- add tests for backend arg construction and command wiring\n\n## Validation\n- cargo test (in poor-cli-tui)