### PR TITLE
feat: Neovim multiplayer config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ $ ./run_tui.sh
 $ python -m poor_cli         # wrapper that launches the Rust TUI
 $ pip install -e .
 $ poor-cli                   # wrapper that launches the Rust TUI
+$ poor-cli --remote-url ws://127.0.0.1:8765/rpc --remote-room dev --remote-token <token>
 $ ./uninstall.sh
 ```
 
@@ -81,6 +82,56 @@ $ docker run -it --env-file .env poor-cli
     end,
 }
 ```
+
+## Multiplayer (LAN / Tunnel)
+
+`poor-cli-server` can run in multiplayer WebSocket host mode with room-scoped
+invite tokens and role permissions (`viewer` or `prompter`).
+
+### Start host (LAN)
+
+```console
+$ poor-cli-server --host --bind 0.0.0.0 --port 8765 --room dev --room docs
+```
+
+The host prints:
+- room names
+- viewer/prompter tokens per room
+- ready-to-run join command examples
+
+### Optional ngrok helper
+
+```console
+$ poor-cli-server --host --bind 127.0.0.1 --port 8765 --room dev --ngrok
+```
+
+If `ngrok` is available in PATH, the host also prints `wss://.../rpc` join URLs.
+If ngrok is unavailable/fails, local hosting continues normally.
+
+### Join from TUI
+
+```console
+$ poor-cli --remote-url ws://HOST:8765/rpc --remote-room dev --remote-token <prompter-or-viewer-token>
+```
+
+### Join from Neovim
+
+```lua
+require("poor-cli").setup({
+    multiplayer = {
+        enabled = true,
+        url = "ws://HOST:8765/rpc",
+        room = "dev",
+        token = "<prompter-or-viewer-token>",
+    },
+})
+```
+
+### Tunnel alternatives
+
+You can use cloudflared, Tailscale funnel, or any reverse tunnel/provider.
+Expose the host `/rpc` endpoint and pass the resulting `ws://` or `wss://` URL
+to `--remote-url` / `multiplayer.url`.
 
 ## Available Commands
 

--- a/nvim-poor-cli/lua/poor-cli/config.lua
+++ b/nvim-poor-cli/lua/poor-cli/config.lua
@@ -28,6 +28,14 @@ M.defaults = {
     provider = nil,
     model = nil,
     api_key_env = nil,
+
+    -- Multiplayer remote bridge mode
+    multiplayer = {
+        enabled = false,
+        url = nil,
+        room = nil,
+        token = nil,
+    },
     
     -- UI options
     chat_width = 60,

--- a/nvim-poor-cli/lua/poor-cli/rpc.lua
+++ b/nvim-poor-cli/lua/poor-cli/rpc.lua
@@ -80,6 +80,30 @@ local function schedule_restart()
     )
 end
 
+-- Resolve the command used to start the backend server/bridge.
+function M.resolve_server_command()
+    local multiplayer = config.get("multiplayer") or {}
+    if type(multiplayer) == "table" and multiplayer.enabled then
+        local url = multiplayer.url
+        local room = multiplayer.room
+        local token = multiplayer.token
+        if not url or url == "" or not room or room == "" or not token or token == "" then
+            return nil, "multiplayer.enabled requires multiplayer.url, multiplayer.room, and multiplayer.token"
+        end
+        return {
+            "poor-cli-server",
+            "--bridge",
+            "--url",
+            url,
+            "--room",
+            room,
+            "--token",
+            token,
+        }
+    end
+    return config.get("server_cmd"), nil
+end
+
 -- Start the server
 function M.start(is_restart)
     if M.job_id then
@@ -90,9 +114,13 @@ function M.start(is_restart)
     clear_restart_timer()
     M.manual_stop = false
 
-    local cmd = config.get("server_cmd")
+    local cmd, err = M.resolve_server_command()
+    if not cmd then
+        vim.notify("[poor-cli] " .. (err or "Failed to resolve server command"), vim.log.levels.ERROR)
+        return nil
+    end
     if config.is_debug() then
-        vim.notify("[poor-cli] Starting server: " .. cmd, vim.log.levels.DEBUG)
+        vim.notify("[poor-cli] Starting server: " .. vim.inspect(cmd), vim.log.levels.DEBUG)
     end
 
     M.job_id = vim.fn.jobstart(cmd, {

--- a/nvim-poor-cli/tests/test_rpc.lua
+++ b/nvim-poor-cli/tests/test_rpc.lua
@@ -21,6 +21,12 @@ describe("poor-cli.rpc", function()
             rpc.restart_timer:close()
             rpc.restart_timer = nil
         end
+        config.config.multiplayer = {
+            enabled = false,
+            url = nil,
+            room = nil,
+            token = nil,
+        }
     end)
     
     after_each(function()
@@ -41,6 +47,46 @@ describe("poor-cli.rpc", function()
         
         it("should have request_id starting at 0", function()
             assert.are.equal(0, rpc.request_id)
+        end)
+    end)
+
+    describe("command resolution", function()
+        it("should resolve default server command when multiplayer is disabled", function()
+            config.config.multiplayer = { enabled = false }
+            local cmd, err = rpc.resolve_server_command()
+            assert.is_nil(err)
+            assert.are.equal(config.get("server_cmd"), cmd)
+        end)
+
+        it("should resolve bridge command when multiplayer is enabled", function()
+            config.config.multiplayer = {
+                enabled = true,
+                url = "wss://example.test/rpc",
+                room = "dev",
+                token = "tok-123",
+            }
+            local cmd, err = rpc.resolve_server_command()
+            assert.is_nil(err)
+            assert.are.same({
+                "poor-cli-server",
+                "--bridge",
+                "--url",
+                "wss://example.test/rpc",
+                "--room",
+                "dev",
+                "--token",
+                "tok-123",
+            }, cmd)
+        end)
+
+        it("should error when multiplayer config is incomplete", function()
+            config.config.multiplayer = {
+                enabled = true,
+                url = "wss://example.test/rpc",
+            }
+            local cmd, err = rpc.resolve_server_command()
+            assert.is_nil(cmd)
+            assert.is_not_nil(err)
         end)
     end)
     


### PR DESCRIPTION
## Summary\n- add Neovim multiplayer config block (url/room/token/enabled)\n- resolve RPC server command to bridge mode when multiplayer is enabled\n- add Lua tests for multiplayer command resolution\n- document multiplayer host/join workflow for TUI + Neovim in README\n\n## Validation\n- .venv/bin/pytest tests/test_server.py tests/test_streaming_notifications.py\n- manual note: busted is not installed in this environment