### PR TITLE
prd-002: async-only permission callback (remove sync/async duck-typing)

### DIFF
--- a/poor_cli/agent_runner.py
+++ b/poor_cli/agent_runner.py
@@ -496,7 +496,8 @@ async def run_agent_worker(agent_id: str, repo_root: str) -> None:
         return
 
     # auto-approve all tools based on sandbox preset
-    core._permission_callback = _auto_approve_callback(agent.sandbox_preset)
+    from .permission_engine import _as_async
+    core._permission_callback = _as_async(_auto_approve_callback(agent.sandbox_preset))
 
     accumulated_text = ""
     done_reason = ""

--- a/poor_cli/core.py
+++ b/poor_cli/core.py
@@ -8,6 +8,7 @@ the Neovim plugin.
 import asyncio
 import difflib
 import hashlib
+import inspect
 import json
 import os
 import subprocess
@@ -1674,10 +1675,7 @@ class PoorCLICore(PermissionEngineMixin, ContextEngineMixin, ProviderInfoMixin):
             )
             return decision
 
-        try:
-            decision = await self._permission_callback(tool_name, tool_args, preview)
-        except TypeError:
-            decision = await self._permission_callback(tool_name, tool_args)
+        decision = await self._permission_callback(tool_name, tool_args, preview)
         normalized = self._normalize_permission_decision(decision)
         if normalized["allowed"] and self.config and getattr(self.config.agentic, "path_scoped_approval", True):
             target_paths = self._inspect_tool_targets(tool_name, tool_args)
@@ -4995,17 +4993,17 @@ class PoorCLICore(PermissionEngineMixin, ContextEngineMixin, ProviderInfoMixin):
     def permission_callback(self, callback: Optional[Callable[..., Any]]) -> None:
         """
         Set the permission callback for file operations.
-        
-        The callback should be an async function that takes:
-            - tool_name: str - Name of the tool being executed
-            - tool_args: dict - Arguments to the tool
-        
-        And returns:
-            - bool - True to allow, False to deny
-        
-        Args:
-            callback: The permission callback function.
+
+        The callback MUST be a coroutine function with signature
+        ``async (tool_name: str, tool_args: dict, preview: dict | None) -> dict``.
+        Legacy sync callables should be wrapped via
+        ``poor_cli.permission_engine._as_async`` at the registration site.
         """
+        if callback is not None and not inspect.iscoroutinefunction(callback):
+            raise TypeError(
+                "permission_callback must be a coroutine function; "
+                "wrap legacy sync callbacks via permission_engine._as_async"
+            )
         self._permission_callback = callback
         logger.info("Permission callback updated")
 

--- a/poor_cli/permission_engine.py
+++ b/poor_cli/permission_engine.py
@@ -7,6 +7,9 @@ and tool execution with policy hooks.
 from __future__ import annotations
 
 import asyncio
+import functools
+import inspect
+from collections.abc import Awaitable
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -20,6 +23,47 @@ _MUTATING_TOOLS = {
     "write_file", "edit_file", "delete_file",
     "apply_patch_unified", "json_yaml_edit",
 }
+
+PermissionDecision = Dict[str, Any]
+PermissionCallback = Callable[[str, Dict[str, Any], Optional[Dict[str, Any]]], Awaitable[PermissionDecision]]
+
+
+def _as_async(cb: Callable[..., Any]) -> PermissionCallback:
+    """Wrap a permission callback into a 3-arg async coroutine.
+
+    Accepts either an async or sync callable. If the callable's signature does
+    not accept a ``preview`` argument, the wrapper drops it before forwarding.
+    Use this at every registration site that still passes a legacy shape.
+
+    This callable MUST be a coroutine function once stored on the core; pass
+    legacy sync functions through this helper first.
+    """
+    try:
+        sig = inspect.signature(cb)
+        accepts_preview = len(sig.parameters) >= 3 or any(
+            p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+            for p in sig.parameters.values()
+        )
+    except (TypeError, ValueError):
+        accepts_preview = True
+
+    if inspect.iscoroutinefunction(cb):
+        if accepts_preview:
+            return cb
+
+        @functools.wraps(cb)
+        async def async_wrapped(tool: str, args: Dict[str, Any], preview: Optional[Dict[str, Any]] = None) -> PermissionDecision:
+            return await cb(tool, args)
+
+        return async_wrapped
+
+    @functools.wraps(cb)
+    async def sync_wrapped(tool: str, args: Dict[str, Any], preview: Optional[Dict[str, Any]] = None) -> PermissionDecision:
+        if accepts_preview:
+            return cb(tool, args, preview)
+        return cb(tool, args)
+
+    return sync_wrapped
 
 
 class PermissionEngineMixin:
@@ -92,10 +136,7 @@ class PermissionEngineMixin:
                 "approvedChunks": [], "source": "default-allow",
             })
             return decision
-        try:
-            decision = await self._permission_callback(tool_name, tool_args, preview)
-        except TypeError:
-            decision = await self._permission_callback(tool_name, tool_args)
+        decision = await self._permission_callback(tool_name, tool_args, preview)
         normalized = self._normalize_permission_decision(decision)
         if normalized["allowed"] and self.config and getattr(self.config.agentic, "path_scoped_approval", True):
             target_paths = self._inspect_tool_targets(tool_name, tool_args)

--- a/tests/test_permission_callback_async.py
+++ b/tests/test_permission_callback_async.py
@@ -1,0 +1,102 @@
+"""Tests for async-only permission callback contract (PRD 002)."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from poor_cli.permission_engine import (
+    PermissionCallback,
+    _as_async,
+)
+
+
+def _make_core(callback=None):
+    from poor_cli.core import PoorCLICore
+    core = object.__new__(PoorCLICore)
+    core.config = MagicMock()
+    core.config.agentic.path_scoped_approval = False
+    core._approved_write_paths = set()
+    core._permission_callback = None
+    core._hook_manager = None
+    core.tool_registry = None
+    if callback is not None:
+        core.permission_callback = callback
+    return core
+
+
+class TestPermissionCallbackAsync(unittest.TestCase):
+    def test_async_callback_awaited(self):
+        calls = []
+
+        async def cb(tool, args, preview=None):
+            calls.append((tool, args, preview))
+            return {"allowed": True, "approvedPaths": [], "approvedChunks": []}
+
+        core = _make_core(cb)
+        result = asyncio.run(core._request_permission("write_file", {"path": "/tmp/x"}))
+        self.assertTrue(result["allowed"])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "write_file")
+
+    def test_sync_callback_wrapped_via_as_async(self):
+        calls = []
+
+        def sync_cb(tool, args, preview=None):
+            calls.append((tool, args, preview))
+            return {"allowed": True}
+
+        wrapped = _as_async(sync_cb)
+        core = _make_core(wrapped)
+        result = asyncio.run(core._request_permission("write_file", {"path": "/tmp/x"}))
+        self.assertTrue(result["allowed"])
+        self.assertEqual(len(calls), 1)
+
+    def test_raw_sync_callback_rejected_at_registration(self):
+        def sync_cb(tool, args, preview=None):
+            return {"allowed": True}
+
+        core = _make_core()
+        with self.assertRaises(TypeError):
+            core.permission_callback = sync_cb
+
+    def test_unrelated_typeerror_propagates(self):
+        async def bad_cb(tool, args, preview=None):
+            val = None
+            return val["missing"]
+
+        core = _make_core(bad_cb)
+        with self.assertRaises(TypeError):
+            asyncio.run(core._request_permission("write_file", {"path": "/tmp/x"}))
+
+    def test_permission_decision_shape_unchanged(self):
+        async def cb(tool, args, preview=None):
+            return {"allowed": True, "approvedPaths": ["/tmp/x"], "approvedChunks": []}
+
+        core = _make_core(cb)
+        result = asyncio.run(core._request_permission("write_file", {"path": "/tmp/x"}))
+        self.assertEqual(set(result.keys()), {"allowed", "approvedPaths", "approvedChunks"})
+        self.assertTrue(result["allowed"])
+        self.assertEqual(result["approvedPaths"], ["/tmp/x"])
+        self.assertEqual(result["approvedChunks"], [])
+
+    def test_as_async_passes_through_async_callback(self):
+        async def cb(tool, args, preview=None):
+            return {"allowed": True}
+
+        self.assertIs(_as_async(cb), cb)
+
+    def test_as_async_wraps_two_arg_sync_callback(self):
+        def legacy(tool, args):
+            return {"allowed": True, "got_args": args}
+
+        wrapped = _as_async(legacy)
+        result = asyncio.run(wrapped("t", {"a": 1}, {"paths": ["/x"]}))
+        self.assertTrue(result["allowed"])
+        self.assertEqual(result["got_args"], {"a": 1})
+
+    def test_permission_callback_type_alias_exists(self):
+        self.assertIsNotNone(PermissionCallback)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,7 +1,7 @@
 """tests for poor_cli.session_manager module."""
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 from poor_cli.session_manager import SessionManager, SessionState
 from poor_cli.exceptions import ValidationError
 
@@ -113,7 +113,7 @@ class TestSessionManager(unittest.TestCase):
 
     def test_permission_callback_propagated(self):
         mgr = self._make_mgr()
-        cb = MagicMock()
+        cb = AsyncMock()
         mgr.set_permission_callback(cb)
         s = mgr.create_session(label="new")
         self.assertEqual(s.core.permission_callback, cb)


### PR DESCRIPTION
## Summary
- Replace the `try/except TypeError` duck-typing around the permission callback with an unconditional `await` and enforce coroutine-functionness at registration time.
- Add `PermissionCallback` type alias + `_as_async` helper in `poor_cli/permission_engine.py` so legacy sync / 2-arg callbacks can be wrapped at their registration site instead of silently retried at the call site.
- Update `poor_cli/agent_runner.py` and `tests/test_session_manager.py` to pass coroutine callbacks through the new contract.

Implements [PRD 002](prd/002-async-only-permission-callback.md). Closes LEARNING.md §2.1.

## Done criteria (from PRD)
- [x] No `except TypeError` near the permission callback anywhere in `poor_cli/`.
- [x] `grep -n "_permission_callback" poor_cli/core.py` shows exactly one `await` call and no ceremony.
- [x] Registration enforces coroutine-ness (TypeError raised at setter).
- [x] New tests in `tests/test_permission_callback_async.py` pass, including the regression test that an unrelated `TypeError` inside the callback propagates instead of being swallowed.

## Test plan
- [ ] `python -m pytest tests/test_permission_callback_async.py tests/test_path_scoped_approval.py tests/test_session_manager.py -v` — all green locally.
- [ ] `make lint` — no new errors introduced by this PR (pre-existing F401s in `permission_engine.py` / `agent_runner.py` remain, out of scope per PRD).
- [ ] Manual: run `poor-cli exec --prompt "write a hello.txt"` and confirm the permission prompt still works end-to-end in CLI and Neovim bridge.