### PR TITLE
prd-004: Fix semantic cache key to hash file contents

### DIFF
--- a/poor_cli/audit_log.py
+++ b/poor_cli/audit_log.py
@@ -37,6 +37,9 @@ class AuditEventType(Enum):
     TOOL_EXECUTION = "tool_execution"
     HOOK_ALLOW = "hook_allow"
     HOOK_DENY = "hook_deny"
+    CACHE_HIT = "cache_hit"
+    CACHE_MISS = "cache_miss"
+    CACHE_INVALIDATE = "cache_invalidate"
 
 
 class AuditSeverity(Enum):

--- a/poor_cli/core.py
+++ b/poor_cli/core.py
@@ -3047,10 +3047,23 @@ class PoorCLICore(PermissionEngineMixin, ContextEngineMixin, ProviderInfoMixin):
             logger.warning("working memory pre-turn failed: %s", e)
 
         # Economy: compute context hash for semantic cache keying
+        # PRD 004: fold in system-prompt and tool-schema fingerprints so edits
+        # to either invalidate previously-cached answers.
+        tool_schema_hash = None
+        try:
+            decls = getattr(self, "_active_tool_declarations", None)
+            if decls:
+                tool_schema_hash = hashlib.sha256(
+                    json.dumps(decls, sort_keys=True, default=str).encode("utf-8", errors="replace")
+                ).hexdigest()
+        except Exception:
+            tool_schema_hash = None
         self._last_context_hash = compute_context_hash(
             context_files=context_files,
             pinned_context_files=pinned_context_files,
             model_name=self.provider.model_name if self.provider else "",
+            system_prompt_hash=getattr(self, "_system_context_hash", None),
+            tool_schema_hash=tool_schema_hash,
         )
 
         # Economy: response cache lookup (exact match, then semantic)

--- a/poor_cli/file_cache.py
+++ b/poor_cli/file_cache.py
@@ -378,3 +378,60 @@ def get_file_cache(max_size: int = 128) -> FileCache:
     if _file_cache is None:
         _file_cache = FileCache(max_size=max_size)
     return _file_cache
+
+
+# ── content fingerprint (for semantic cache key, PRD 004) ────────────
+
+_FINGERPRINT_MAX = 2048
+_FINGERPRINT_CACHE: "OrderedDict[str, Tuple[int, int, str]]" = OrderedDict()
+_MISSING_FINGERPRINT = "missing"
+_ERROR_FINGERPRINT = "err"
+
+
+def _hash_file_bytes(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def content_fingerprint(path) -> str:
+    """Return a stable hash of file contents.
+
+    Uses (mtime_ns, size) as a cheap cache key and computes sha256 only
+    when the underlying file has actually changed. Memoized in a bounded
+    in-process LRU so repeated calls on unchanged files do zero disk work
+    beyond the initial stat().
+
+    Returns a sentinel string for missing or unreadable files so callers
+    can still fold the path into a stable hash without crashing.
+    """
+    p = Path(path)
+    key = str(p)
+    try:
+        st = p.stat()
+    except FileNotFoundError:
+        return _MISSING_FINGERPRINT
+    except OSError:
+        return _ERROR_FINGERPRINT
+    mtime_ns = st.st_mtime_ns
+    size = st.st_size
+    cached = _FINGERPRINT_CACHE.get(key)
+    if cached is not None and cached[0] == mtime_ns and cached[1] == size:
+        _FINGERPRINT_CACHE.move_to_end(key)
+        return cached[2]
+    try:
+        digest = _hash_file_bytes(p)
+    except OSError:
+        return _ERROR_FINGERPRINT
+    _FINGERPRINT_CACHE[key] = (mtime_ns, size, digest)
+    _FINGERPRINT_CACHE.move_to_end(key)
+    while len(_FINGERPRINT_CACHE) > _FINGERPRINT_MAX:
+        _FINGERPRINT_CACHE.popitem(last=False)
+    return digest
+
+
+def reset_fingerprint_cache() -> None:
+    """Clear the fingerprint memo (for tests)."""
+    _FINGERPRINT_CACHE.clear()

--- a/poor_cli/semantic_cache.py
+++ b/poor_cli/semantic_cache.py
@@ -25,6 +25,11 @@ DEFAULT_SIMILARITY_THRESHOLD = 0.92
 DEFAULT_TTL_SECONDS = 86400 # 24h
 DEFAULT_MAX_ENTRIES = 2048
 
+# Bumped when the context-hash algorithm changes — on first load with a
+# mismatched version row, pre-existing entries are wiped so stale keys
+# can't serve stale answers. PRD 004.
+CACHE_SCHEMA_VERSION = 2
+
 
 @dataclass
 class CacheResult:
@@ -102,10 +107,47 @@ class SemanticCache:
                 CREATE INDEX IF NOT EXISTS idx_created_at
                 ON semantic_cache(created_at)
             """)
+            self._db.execute("""
+                CREATE TABLE IF NOT EXISTS semantic_cache_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+            """)
             self._db.commit()
+            self._migrate_schema()
         except Exception as e:
             logger.error("semantic cache db init failed: %s", e)
             self._db = None
+
+    def _migrate_schema(self) -> None:
+        """Wipe entries from earlier cache-key schemas so weak keys can't leak."""
+        if not self._db:
+            return
+        try:
+            row = self._db.execute(
+                "SELECT value FROM semantic_cache_meta WHERE key = 'schema_version'"
+            ).fetchone()
+            current = int(row[0]) if row and row[0] is not None else 1
+        except Exception:
+            current = 1
+        if current >= CACHE_SCHEMA_VERSION:
+            return
+        try:
+            wiped = self._db.execute("SELECT COUNT(*) FROM semantic_cache").fetchone()[0]
+            self._db.execute("DELETE FROM semantic_cache")
+            self._db.execute(
+                "INSERT OR REPLACE INTO semantic_cache_meta(key, value) VALUES ('schema_version', ?)",
+                (str(CACHE_SCHEMA_VERSION),),
+            )
+            self._db.commit()
+            if wiped:
+                self._stats.invalidations += wiped
+                logger.info(
+                    "semantic cache schema bumped v%d to v%d; wiped %d stale entries",
+                    current, CACHE_SCHEMA_VERSION, wiped,
+                )
+        except Exception as e:
+            logger.warning("semantic cache schema migration failed: %s", e)
 
     def _get_provider(self) -> Optional[EmbeddingProvider]:
         if self._provider is None:

--- a/poor_cli/semantic_cache.py
+++ b/poor_cli/semantic_cache.py
@@ -211,8 +211,10 @@ class SemanticCache:
                 self._db.commit()
             except Exception:
                 pass
+            _audit_cache_event("cache_hit", context_hash, similarity=best.similarity)
             return best
         self._stats.misses += 1
+        _audit_cache_event("cache_miss", context_hash)
         return None
 
     async def put(
@@ -283,6 +285,8 @@ class SemanticCache:
             self._db.commit()
             n = cursor.rowcount
             self._stats.invalidations += n
+            if n:
+                _audit_cache_event("cache_invalidate", context_hash, removed=n)
             return n
         except Exception as e:
             logger.warning("semantic cache invalidation failed: %s", e)
@@ -297,6 +301,8 @@ class SemanticCache:
             self._db.execute("DELETE FROM semantic_cache")
             self._db.commit()
             self._stats.invalidations += count
+            if count:
+                _audit_cache_event("cache_invalidate", "*", removed=count, scope="all")
             return count
         except Exception as e:
             logger.warning("semantic cache clear failed: %s", e)
@@ -354,6 +360,34 @@ class SemanticCache:
             except Exception:
                 pass
             self._db = None
+
+
+# ── audit logging (best-effort, never raises) ───────────────────────
+
+def _audit_cache_event(kind: str, context_hash: str, **details: Any) -> None:
+    """Record a cache hit/miss/invalidation to the audit log.
+
+    Best-effort: failures must never block the fast cache path.
+    """
+    try:
+        from .audit_log import AuditEventType, get_audit_logger
+
+        event_map = {
+            "cache_hit": AuditEventType.CACHE_HIT,
+            "cache_miss": AuditEventType.CACHE_MISS,
+            "cache_invalidate": AuditEventType.CACHE_INVALIDATE,
+        }
+        event_type = event_map.get(kind)
+        if event_type is None:
+            return
+        get_audit_logger().log_event(
+            event_type=event_type,
+            operation=f"semantic_cache:{kind}",
+            target=context_hash,
+            details={k: v for k, v in details.items() if v is not None},
+        )
+    except Exception:
+        pass
 
 
 # ── context hashing ─────────────────────────────────────────────────

--- a/poor_cli/semantic_cache.py
+++ b/poor_cli/semantic_cache.py
@@ -320,22 +320,35 @@ def compute_context_hash(
     context_files: Optional[List[str]] = None,
     pinned_context_files: Optional[List[str]] = None,
     model_name: str = "",
+    system_prompt_hash: Optional[str] = None,
+    tool_schema_hash: Optional[str] = None,
+    rules_hash: Optional[str] = None,
 ) -> str:
-    """Compute a deterministic hash over the active file set + model.
+    """Compute a deterministic hash over the active context.
 
-    File content is NOT hashed (too expensive). Instead we hash sorted
-    file paths + their mtime so the cache auto-invalidates when any
-    referenced file changes on disk.
+    Folds in a sha256 content fingerprint for every referenced file
+    (memoized by mtime+size in `file_cache`, so unchanged files cost
+    one stat call per lookup), plus optional hashes for the system
+    prompt, active tool schema, and active rules/memory so any change
+    to those invalidates the response cache.
+
+    Edits to a file invalidate the key even if the path stays the
+    same — the stale-answer class of bug from LEARNING.md §2.1.
     """
-    parts: List[str] = [model_name]
+    # Local import to avoid circular import at module load time.
+    from .file_cache import content_fingerprint
+
+    parts: List[str] = [f"m={model_name}"]
     all_files = sorted(set((context_files or []) + (pinned_context_files or [])))
     for fp in all_files:
-        p = Path(fp)
-        try:
-            mtime = str(p.stat().st_mtime) if p.exists() else "missing"
-        except OSError:
-            mtime = "err"
-        parts.append(f"{fp}:{mtime}")
+        fprint = content_fingerprint(fp)
+        parts.append(f"{fp}\x00{fprint}\x01")
+    if system_prompt_hash:
+        parts.append(f"sp={system_prompt_hash}")
+    if tool_schema_hash:
+        parts.append(f"ts={tool_schema_hash}")
+    if rules_hash:
+        parts.append(f"rules={rules_hash}")
     raw = "|".join(parts)
     return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:24]
 

--- a/tests/test_semantic_cache_key.py
+++ b/tests/test_semantic_cache_key.py
@@ -136,5 +136,63 @@ class TestContextHashContentAware(unittest.TestCase):
         self.assertNotEqual(h_before, h_after)
 
 
+class TestSchemaMigration(unittest.TestCase):
+    """PRD 004: old cache entries must be wiped when the key algorithm bumps."""
+
+    def test_legacy_db_is_wiped_on_load(self):
+        import sqlite3
+
+        from poor_cli.semantic_cache import CACHE_SCHEMA_VERSION, SemanticCache
+
+        tmpdir = tempfile.mkdtemp()
+        db_path = Path(tmpdir) / "legacy.db"
+        try:
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                """
+                CREATE TABLE semantic_cache (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    query TEXT NOT NULL,
+                    query_hash TEXT NOT NULL,
+                    context_hash TEXT NOT NULL,
+                    response TEXT NOT NULL,
+                    embedding TEXT NOT NULL,
+                    model_name TEXT DEFAULT '',
+                    created_at REAL NOT NULL,
+                    last_hit_at REAL,
+                    hit_count INTEGER DEFAULT 0,
+                    response_tokens_est INTEGER DEFAULT 0
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO semantic_cache "
+                "(query, query_hash, context_hash, response, embedding, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("old q", "qh", "path-only-hash", "stale", "[]", time.time()),
+            )
+            conn.commit()
+            conn.close()
+
+            cache = SemanticCache(db_path=db_path)
+            try:
+                conn = sqlite3.connect(str(db_path))
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM semantic_cache"
+                ).fetchone()[0]
+                version_row = conn.execute(
+                    "SELECT value FROM semantic_cache_meta WHERE key='schema_version'"
+                ).fetchone()
+                conn.close()
+            finally:
+                cache.close()
+            self.assertEqual(count, 0)
+            self.assertIsNotNone(version_row)
+            self.assertEqual(int(version_row[0]), CACHE_SCHEMA_VERSION)
+        finally:
+            if db_path.exists():
+                db_path.unlink()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_semantic_cache_key.py
+++ b/tests/test_semantic_cache_key.py
@@ -1,0 +1,140 @@
+"""Tests for PRD 004 — content-aware semantic cache key.
+
+Verifies that `compute_context_hash` hashes file *contents* (not just paths
+and mtimes) and folds in system-prompt / tool-schema / rules fingerprints,
+so that edits invalidate cached answers.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from poor_cli.file_cache import content_fingerprint
+from poor_cli.semantic_cache import compute_context_hash
+
+
+class TestContentFingerprint(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.path = Path(self._tmpdir) / "sample.txt"
+        self.path.write_text("hello")
+
+    def tearDown(self):
+        if self.path.exists():
+            self.path.unlink()
+
+    def test_fingerprint_is_stable(self):
+        a = content_fingerprint(self.path)
+        b = content_fingerprint(self.path)
+        self.assertEqual(a, b)
+        self.assertTrue(len(a) > 0)
+
+    def test_fingerprint_changes_when_content_changes(self):
+        before = content_fingerprint(self.path)
+        time.sleep(0.01)
+        self.path.write_text("hello world")
+        after = content_fingerprint(self.path)
+        self.assertNotEqual(before, after)
+
+    def test_fingerprint_same_path_mtime_different_content(self):
+        """Even if mtime is the same, different content must yield different hash.
+
+        Simulates rare in-same-second rewrites by forcing mtime to a fixed value.
+        """
+        before = content_fingerprint(self.path)
+        st = self.path.stat()
+        self.path.write_text("goodbye")
+        # Restore mtime+size-is-different case: pin mtime to pre-write time.
+        os.utime(self.path, (st.st_atime, st.st_mtime))
+        after = content_fingerprint(self.path)
+        # Size differs ("hello" vs "goodbye"), so memo key must reflect that.
+        self.assertNotEqual(before, after)
+
+    def test_fingerprint_missing_file(self):
+        missing = Path(self._tmpdir) / "does_not_exist.txt"
+        h = content_fingerprint(missing)
+        self.assertTrue(len(h) > 0)  # stable sentinel, no crash
+
+    def test_fingerprint_cached_by_mtime(self):
+        """Unchanged files should not be re-hashed on repeat calls."""
+        content_fingerprint(self.path)  # warm cache
+        with patch("poor_cli.file_cache._hash_file_bytes") as mock_hash:
+            mock_hash.return_value = "SHOULD_NOT_BE_CALLED"
+            content_fingerprint(self.path)
+            content_fingerprint(self.path)
+            self.assertEqual(mock_hash.call_count, 0)
+
+
+class TestContextHashContentAware(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.file = Path(self._tmpdir) / "ctx.py"
+        self.file.write_text("x = 1\n")
+
+    def tearDown(self):
+        if self.file.exists():
+            self.file.unlink()
+
+    def test_key_changes_when_file_content_changes(self):
+        h1 = compute_context_hash(context_files=[str(self.file)])
+        time.sleep(0.01)
+        self.file.write_text("x = 2\n")
+        h2 = compute_context_hash(context_files=[str(self.file)])
+        self.assertNotEqual(h1, h2)
+
+    def test_key_stable_when_nothing_changes(self):
+        h1 = compute_context_hash(context_files=[str(self.file)])
+        h2 = compute_context_hash(context_files=[str(self.file)])
+        self.assertEqual(h1, h2)
+
+    def test_key_changes_when_system_prompt_changes(self):
+        h1 = compute_context_hash(
+            context_files=[str(self.file)], system_prompt_hash="sp_v1"
+        )
+        h2 = compute_context_hash(
+            context_files=[str(self.file)], system_prompt_hash="sp_v2"
+        )
+        self.assertNotEqual(h1, h2)
+
+    def test_key_changes_when_tool_schema_changes(self):
+        h1 = compute_context_hash(
+            context_files=[str(self.file)], tool_schema_hash="ts_v1"
+        )
+        h2 = compute_context_hash(
+            context_files=[str(self.file)], tool_schema_hash="ts_v2"
+        )
+        self.assertNotEqual(h1, h2)
+
+    def test_key_changes_when_rules_change(self):
+        h1 = compute_context_hash(
+            context_files=[str(self.file)], rules_hash="rules_v1"
+        )
+        h2 = compute_context_hash(
+            context_files=[str(self.file)], rules_hash="rules_v2"
+        )
+        self.assertNotEqual(h1, h2)
+
+    def test_stale_cache_regression_from_readme_example(self):
+        """Regression for LEARNING.md §2.1:
+        user edits file, re-asks same question, must NOT get stale cached answer.
+        The check here is at the key level: same paths, same model, different
+        file contents → different keys → guaranteed miss.
+        """
+        h_before = compute_context_hash(
+            context_files=[str(self.file)], model_name="mX"
+        )
+        time.sleep(0.01)
+        self.file.write_text("# totally different content\nprint('hi')\n")
+        h_after = compute_context_hash(
+            context_files=[str(self.file)], model_name="mX"
+        )
+        self.assertNotEqual(h_before, h_after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `semantic_cache.compute_context_hash` now folds in a sha256 content
  fingerprint for every referenced file (plus optional system-prompt,
  tool-schema, and rules-hash kwargs). Edits to a file now invalidate
  the cache instead of silently serving stale answers — the correctness
  bug from LEARNING.md §2.1 / PRD 004.
- `file_cache.content_fingerprint` hashes with an `(mtime_ns, size)`
  memo so unchanged files cost one stat() per lookup, not a full re-hash.
- Schema-version bump (`CACHE_SCHEMA_VERSION=2` + `semantic_cache_meta`
  table): on first open, pre-existing v1 entries with path-only keys are
  wiped so they can't resurrect as stale hits.
- Audit log now emits `cache_hit` / `cache_miss` / `cache_invalidate`
  events for the forthcoming cost dashboard (PRD 016).

## Done criteria (from PRD)
- [x] `_context_hash` incorporates content fingerprints.
- [x] Edit → cache miss (proven by `test_key_changes_when_file_content_changes`).
- [x] No new disk-I/O per lookup on unchanged files (proven by
      `test_fingerprint_cached_by_mtime` — the inner sha256 is never called
      on a warm entry).
- [x] Audit log records cache hit / miss events.

Users will see a one-time spike in cache misses after upgrading. Intentional
and documented in the PRD rollback section.

## Test plan
- [x] `tests/test_semantic_cache_key.py` — 12 new tests, all green.
- [x] `tests/test_semantic_cache.py` — 16 pre-existing tests, still green.
- [x] Full project test run: 900 passed, 35 skipped (excluding four pre-existing
      env-only failures unrelated to this PRD: `test_neural_encoder` needs
      torch, `test_product_contracts`/`test_prompt_caching` need anthropic+
      aiortc pins, `test_sandbox_os_level` needs sandbox-exec).
- [x] Lint: no new ruff errors introduced in the three files touched by this
      PRD (10 → 9 on those files; the rest of the repo's 203 pre-existing
      errors are out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)