### PR TITLE
prd-003: schema-version persisted state with migration framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 .poor-cli/*
 !.poor-cli/tool_projections.yaml
 .poor-cli/preferences.json
+.poor-cli/.legacy-v0/
 poor-cli.log
 
 # Checkpoints (stored in .poor-cli/checkpoints/)

--- a/poor_cli/audit_log.py
+++ b/poor_cli/audit_log.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, asdict
 from enum import Enum
 
 from poor_cli.exceptions import setup_logger
+from poor_cli.persisted import run_sqlite_migrations
 
 logger = setup_logger(__name__)
 
@@ -135,6 +136,7 @@ class AuditLogger:
                 CREATE INDEX IF NOT EXISTS idx_user ON audit_events(user)
             """)
 
+            run_sqlite_migrations(conn, "audit")
             conn.commit()
             conn.close()
             logger.debug("Audit database initialized")

--- a/poor_cli/automation_manager.py
+++ b/poor_cli/automation_manager.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from .persisted import run_sqlite_migrations
 from .run_history import RunHistoryManager
 from .sandbox import normalize_preset
 from .task_manager import APPROVAL_REQUIRED_PRESETS, TaskManager, TaskRecord
@@ -365,6 +366,7 @@ class AutomationManager:
                 )
                 """
             )
+            run_sqlite_migrations(conn, "automation")
 
     def create_automation(
         self,

--- a/poor_cli/checkpoint.py
+++ b/poor_cli/checkpoint.py
@@ -20,6 +20,7 @@ from threading import Thread, Event
 import time
 
 from poor_cli.exceptions import FileOperationError, setup_logger
+from poor_cli.persisted import load_json, save_json
 
 logger = setup_logger(__name__)
 
@@ -173,8 +174,7 @@ class CheckpointManager:
         """Load checkpoint index from disk"""
         try:
             if self.index_file.exists():
-                with open(self.index_file, 'r') as f:
-                    data = json.load(f)
+                data = load_json(self.index_file, "checkpoint") or {}
 
                 # Load checkpoint metadata (not file content)
                 for cp_data in data.get("checkpoints", []):
@@ -219,8 +219,7 @@ class CheckpointManager:
                 "checkpoints": [cp.to_dict() for cp in self.checkpoints]
             }
 
-            with open(self.index_file, 'w') as f:
-                json.dump(data, f, indent=2)
+            save_json(self.index_file, "checkpoint", data)
 
             logger.debug("Saved checkpoint index")
 

--- a/poor_cli/checkpoint.py
+++ b/poor_cli/checkpoint.py
@@ -6,7 +6,6 @@ Stores snapshots in .poor-cli/checkpoints/
 """
 
 import os
-import json
 import shutil
 import hashlib
 import zlib

--- a/poor_cli/history.py
+++ b/poor_cli/history.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, asdict
 from contextlib import contextmanager
 from threading import Lock
 from poor_cli.exceptions import FileOperationError, setup_logger
+from poor_cli.persisted import run_sqlite_migrations
 from poor_cli.provider_catalog import default_model_for_provider
 
 logger = setup_logger(__name__)
@@ -313,6 +314,8 @@ class HistoryManager:
                 """)
 
                 self._backfill_fts(conn)
+
+                run_sqlite_migrations(conn, "history")
 
                 # Archived sessions table for old data
                 cursor.execute("""

--- a/poor_cli/persisted/__init__.py
+++ b/poor_cli/persisted/__init__.py
@@ -1,0 +1,35 @@
+"""Schema-versioned persisted state for poor-cli.
+
+See PRD 003 for design rationale. Public surface:
+
+- :func:`load_json` / :func:`save_json` — envelope-wrapped JSON I/O.
+- :func:`seed_sqlite_meta` / :func:`run_sqlite_migrations` — SQLite ``meta`` table helpers.
+- :data:`CURRENT_VERSIONS` — authoritative map of artifact -> current version.
+- Exceptions: :class:`UnknownSchemaVersion`, :class:`ForwardMigrationFailed`.
+"""
+
+from .schema import (
+    CURRENT_VERSIONS,
+    ForwardMigrationFailed,
+    UnknownSchemaVersion,
+    VersionedState,
+    load_json,
+    read_sqlite_version,
+    run_sqlite_migrations,
+    save_json,
+    seed_sqlite_meta,
+    set_sqlite_version,
+)
+
+__all__ = [
+    "CURRENT_VERSIONS",
+    "ForwardMigrationFailed",
+    "UnknownSchemaVersion",
+    "VersionedState",
+    "load_json",
+    "save_json",
+    "read_sqlite_version",
+    "run_sqlite_migrations",
+    "seed_sqlite_meta",
+    "set_sqlite_version",
+]

--- a/poor_cli/persisted/migrations.py
+++ b/poor_cli/persisted/migrations.py
@@ -1,0 +1,71 @@
+"""Forward-only migration registry for persisted-state artifacts.
+
+To add a migration, register a function that takes v_n data and returns
+v_{n+1} data in :data:`MIGRATIONS`. For SQLite migrations, register a
+function that mutates a live connection in :data:`SQLITE_MIGRATIONS`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from .schema import ArtifactId, ForwardMigrationFailed
+
+JsonMigration = Callable[[Any], Any]
+SqliteMigration = Callable[[sqlite3.Connection], None]
+
+
+def _identity(data: Any) -> Any:
+    """v0 -> v1 pure-structural wrap: content is unchanged."""
+    return data
+
+
+# ``MIGRATIONS[artifact][from_version] -> v_{from_version+1} data``
+#
+# v0 is the pre-envelope legacy format. For every current artifact the v0 → v1
+# step is structural only (wrap in envelope; no payload changes), so ``_identity``
+# is correct.
+MIGRATIONS: dict[ArtifactId, dict[int, JsonMigration]] = {
+    "preferences": {0: _identity},
+    "history": {0: _identity},
+    "session": {0: _identity},
+    "session_index": {0: _identity},
+    "automation": {0: _identity},
+    "checkpoint": {0: _identity},
+}
+
+
+SQLITE_MIGRATIONS: dict[ArtifactId, dict[int, SqliteMigration]] = {
+    # SQLite migrations land in the PRDs that introduce schema changes.
+    # Scaffolding only for now — databases are seeded at v1 on creation.
+}
+
+
+def migrate_forward(
+    artifact: ArtifactId,
+    data: Any,
+    *,
+    from_version: int,
+    to_version: int,
+) -> Any:
+    """Apply registered migrations in order from ``from_version`` to ``to_version``."""
+    if from_version == to_version:
+        return data
+    if from_version > to_version:
+        raise ForwardMigrationFailed(
+            f"{artifact!r}: cannot migrate backwards ({from_version} -> {to_version})"
+        )
+
+    chain = MIGRATIONS.get(artifact, {})
+    current = data
+    v = from_version
+    while v < to_version:
+        step = chain.get(v)
+        if step is None:
+            raise ForwardMigrationFailed(
+                f"No migration registered for {artifact!r} v{v} -> v{v + 1}"
+            )
+        current = step(current)
+        v += 1
+    return current

--- a/poor_cli/persisted/schema.py
+++ b/poor_cli/persisted/schema.py
@@ -1,0 +1,245 @@
+"""Schema versioning for persisted-state artifacts.
+
+Every JSON-backed file goes through ``load_json`` / ``save_json`` which wrap
+the payload in a ``{"schema_version", "artifact", "data"}`` envelope. SQLite
+databases declare their version in a ``meta`` table. Loaders refuse to read
+a version newer than ``CURRENT_VERSIONS[artifact]``; migrations run
+forward-only via :mod:`poor_cli.persisted.migrations`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ArtifactId = str
+
+CURRENT_VERSIONS: dict[ArtifactId, int] = {
+    "preferences": 1,
+    "history": 1,
+    "session": 1,
+    "session_index": 1,
+    "automation": 1,
+    "runs": 1,
+    "checkpoint": 1,
+    "audit": 1,
+}
+
+LEGACY_BACKUP_DIRNAME = ".legacy-v0"
+
+
+class UnknownSchemaVersion(Exception):
+    """Raised when a file declares a schema_version newer than this build knows."""
+
+
+class ForwardMigrationFailed(Exception):
+    """Raised when a registered migration function fails or is missing."""
+
+
+@dataclass(frozen=True)
+class VersionedState:
+    schema_version: int
+    artifact: ArtifactId
+    data: Any
+
+
+def _backup_dir_for(path: Path) -> Path:
+    return path.parent / LEGACY_BACKUP_DIRNAME
+
+
+def _backup_legacy(path: Path) -> Path:
+    """Copy the pre-envelope file to ``.legacy-v0/<name>.<ts>.bak`` and return the backup path."""
+    backup_dir = _backup_dir_for(path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_path = backup_dir / f"{path.name}.{ts}.bak"
+    backup_path.write_bytes(path.read_bytes())
+    return backup_path
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f"{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _is_envelope(obj: Any, artifact: ArtifactId) -> bool:
+    return (
+        isinstance(obj, dict)
+        and "schema_version" in obj
+        and "data" in obj
+        and obj.get("artifact", artifact) == artifact
+    )
+
+
+def load_json(
+    path: Path,
+    artifact: ArtifactId,
+    *,
+    default: Any = None,
+) -> Any:
+    """Load a JSON artifact, running forward-migrations as needed.
+
+    If the file is missing, returns ``default`` (or ``None``). If the file
+    exists without the envelope, treats it as v0, runs migrations to current,
+    rewrites the envelope atomically, and keeps a backup in ``.legacy-v0/``.
+    """
+    from .migrations import migrate_forward
+
+    if artifact not in CURRENT_VERSIONS:
+        raise ValueError(f"Unknown artifact id: {artifact!r}")
+
+    current = CURRENT_VERSIONS[artifact]
+
+    if not path.exists():
+        return default
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+
+    if _is_envelope(raw, artifact):
+        version = int(raw["schema_version"])
+        if version > current:
+            raise UnknownSchemaVersion(
+                f"{path}: schema_version {version} is newer than this build "
+                f"(current={current} for artifact {artifact!r}). Upgrade poor-cli."
+            )
+        data = raw["data"]
+        if version < current:
+            data = migrate_forward(artifact, data, from_version=version, to_version=current)
+            _backup_legacy(path)
+            _atomic_write_json(
+                path,
+                {"schema_version": current, "artifact": artifact, "data": data},
+            )
+        return data
+
+    # Legacy v0: unwrapped payload. Back up, migrate, rewrite.
+    _backup_legacy(path)
+    data = migrate_forward(artifact, raw, from_version=0, to_version=current)
+    _atomic_write_json(
+        path,
+        {"schema_version": current, "artifact": artifact, "data": data},
+    )
+    return data
+
+
+def save_json(path: Path, artifact: ArtifactId, data: Any) -> None:
+    """Write ``data`` to ``path`` wrapped in the current envelope (atomic)."""
+    if artifact not in CURRENT_VERSIONS:
+        raise ValueError(f"Unknown artifact id: {artifact!r}")
+    _atomic_write_json(
+        path,
+        {
+            "schema_version": CURRENT_VERSIONS[artifact],
+            "artifact": artifact,
+            "data": data,
+        },
+    )
+
+
+# ── SQLite helpers ───────────────────────────────────────────────────
+
+
+def _ensure_meta_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+
+
+def read_sqlite_version(conn: sqlite3.Connection) -> int | None:
+    """Return the ``schema_version`` row from ``meta``, or ``None`` if absent."""
+    try:
+        cur = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'")
+    except sqlite3.OperationalError:
+        return None
+    row = cur.fetchone()
+    if not row:
+        return None
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def set_sqlite_version(conn: sqlite3.Connection, version: int) -> None:
+    _ensure_meta_table(conn)
+    conn.execute(
+        "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
+        (str(int(version)),),
+    )
+
+
+def seed_sqlite_meta(conn: sqlite3.Connection, artifact: ArtifactId) -> None:
+    """Create the ``meta`` table (if needed) and seed schema_version + artifact.
+
+    Idempotent: uses ``INSERT OR IGNORE`` so existing rows are preserved.
+    """
+    if artifact not in CURRENT_VERSIONS:
+        raise ValueError(f"Unknown artifact id: {artifact!r}")
+    _ensure_meta_table(conn)
+    conn.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES ('schema_version', ?)",
+        (str(CURRENT_VERSIONS[artifact]),),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES ('artifact', ?)",
+        (artifact,),
+    )
+
+
+def run_sqlite_migrations(conn: sqlite3.Connection, artifact: ArtifactId) -> None:
+    """Seed meta then apply any registered SQLite migrations up to current."""
+    from .migrations import SQLITE_MIGRATIONS
+
+    if artifact not in CURRENT_VERSIONS:
+        raise ValueError(f"Unknown artifact id: {artifact!r}")
+    current = CURRENT_VERSIONS[artifact]
+
+    existing = read_sqlite_version(conn)
+    if existing is None:
+        seed_sqlite_meta(conn, artifact)
+        existing = read_sqlite_version(conn) or current
+
+    if existing > current:
+        raise UnknownSchemaVersion(
+            f"SQLite artifact {artifact!r}: schema_version {existing} newer than current {current}"
+        )
+
+    migrations = SQLITE_MIGRATIONS.get(artifact, {})
+    v = existing
+    while v < current:
+        step = migrations.get(v)
+        if step is None:
+            raise ForwardMigrationFailed(
+                f"No SQLite migration registered for {artifact!r} v{v} -> v{v + 1}"
+            )
+        step(conn)
+        v += 1
+        set_sqlite_version(conn, v)
+    conn.commit()

--- a/poor_cli/session_store.py
+++ b/poor_cli/session_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/poor_cli/session_store.py
+++ b/poor_cli/session_store.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .persisted import load_json, save_json
+
 
 class SessionStore:
     """Persists conversation snapshots under .poor-cli/sessions."""
@@ -26,7 +28,7 @@ class SessionStore:
         snapshot = dict(payload)
         snapshot["session_id"] = safe_session_id
         snapshot["saved_at"] = snapshot.get("saved_at") or datetime.now(timezone.utc).isoformat()
-        target.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2), encoding="utf-8")
+        save_json(target, "session", snapshot)
 
         index_entry = {
             "sessionId": safe_session_id,
@@ -62,8 +64,10 @@ class SessionStore:
         if not latest_path.is_file():
             return None
         try:
-            payload = json.loads(latest_path.read_text(encoding="utf-8"))
+            payload = load_json(latest_path, "session")
         except Exception:
+            return None
+        if not isinstance(payload, dict):
             return None
         payload.setdefault("session_id", sessions[0].get("sessionId", ""))
         payload.setdefault("saved_at", sessions[0].get("savedAt", ""))
@@ -83,8 +87,10 @@ class SessionStore:
             if not path.is_file():
                 continue
             try:
-                payload = json.loads(path.read_text(encoding="utf-8"))
+                payload = load_json(path, "session")
             except Exception:
+                continue
+            if not isinstance(payload, dict):
                 continue
             payload.setdefault("session_id", target_session)
             payload.setdefault("saved_at", entry.get("savedAt", ""))
@@ -93,10 +99,8 @@ class SessionStore:
         return None
 
     def _read_index(self) -> List[Dict[str, Any]]:
-        if not self.index_path.is_file():
-            return []
         try:
-            payload = json.loads(self.index_path.read_text(encoding="utf-8"))
+            payload = load_json(self.index_path, "session_index")
         except Exception:
             return []
         if not isinstance(payload, dict):
@@ -116,4 +120,4 @@ class SessionStore:
             "updatedAt": datetime.now(timezone.utc).isoformat(),
             "sessions": entries,
         }
-        self.index_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        save_json(self.index_path, "session_index", payload)

--- a/tests/fixtures/persisted/preferences_v0.json
+++ b/tests/fixtures/persisted/preferences_v0.json
@@ -1,0 +1,6 @@
+{
+  "theme": "dark",
+  "created_at": "2024-01-01T00:00:00",
+  "updated_at": "2024-01-01T00:00:00",
+  "default_model": "gpt-4o"
+}

--- a/tests/test_persisted_migrations.py
+++ b/tests/test_persisted_migrations.py
@@ -1,0 +1,105 @@
+"""Tests for forward-only migrations of persisted-state artifacts (PRD 003)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from poor_cli.persisted import (
+    CURRENT_VERSIONS,
+    ForwardMigrationFailed,
+    load_json,
+)
+from poor_cli.persisted.migrations import MIGRATIONS, migrate_forward
+from poor_cli.persisted.schema import LEGACY_BACKUP_DIRNAME
+
+FIXTURES = Path(__file__).parent / "fixtures" / "persisted"
+
+
+def test_v0_preferences_auto_upgrade(tmp_path: Path) -> None:
+    target = tmp_path / "preferences.json"
+    shutil.copy(FIXTURES / "preferences_v0.json", target)
+
+    original_payload = json.loads(target.read_text(encoding="utf-8"))
+    # Sanity: fixture is truly pre-envelope.
+    assert "schema_version" not in original_payload
+
+    loaded = load_json(target, "preferences")
+    assert loaded == original_payload
+
+    on_disk = json.loads(target.read_text(encoding="utf-8"))
+    assert on_disk == {
+        "schema_version": CURRENT_VERSIONS["preferences"],
+        "artifact": "preferences",
+        "data": original_payload,
+    }
+
+
+def test_legacy_v0_backup_created(tmp_path: Path) -> None:
+    target = tmp_path / "preferences.json"
+    shutil.copy(FIXTURES / "preferences_v0.json", target)
+    expected_content = target.read_bytes()
+
+    load_json(target, "preferences")
+
+    backup_dir = tmp_path / LEGACY_BACKUP_DIRNAME
+    assert backup_dir.is_dir()
+    backups = list(backup_dir.glob("preferences.json.*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == expected_content
+
+
+def test_reload_after_upgrade_does_not_create_second_backup(tmp_path: Path) -> None:
+    target = tmp_path / "preferences.json"
+    shutil.copy(FIXTURES / "preferences_v0.json", target)
+
+    load_json(target, "preferences")
+    load_json(target, "preferences")  # already an envelope — no backup
+
+    backups = list((tmp_path / LEGACY_BACKUP_DIRNAME).glob("preferences.json.*.bak"))
+    assert len(backups) == 1
+
+
+def test_migrate_forward_chains_migrations_in_order() -> None:
+    calls: list[int] = []
+
+    def step(tag: int):
+        def _apply(data):
+            calls.append(tag)
+            return {**data, f"v{tag}": True}
+
+        return _apply
+
+    MIGRATIONS["test_artifact"] = {0: step(1), 1: step(2), 2: step(3)}
+    try:
+        CURRENT_VERSIONS["test_artifact"] = 3
+        result = migrate_forward("test_artifact", {}, from_version=0, to_version=3)
+        assert calls == [1, 2, 3]
+        assert result == {"v1": True, "v2": True, "v3": True}
+    finally:
+        del MIGRATIONS["test_artifact"]
+        del CURRENT_VERSIONS["test_artifact"]
+
+
+def test_missing_migration_raises_explicitly() -> None:
+    MIGRATIONS["gappy"] = {0: lambda d: d}
+    try:
+        CURRENT_VERSIONS["gappy"] = 3
+        with pytest.raises(ForwardMigrationFailed):
+            migrate_forward("gappy", {}, from_version=0, to_version=3)
+    finally:
+        del MIGRATIONS["gappy"]
+        del CURRENT_VERSIONS["gappy"]
+
+
+def test_migrate_forward_identity_when_versions_match() -> None:
+    payload = {"x": 1}
+    assert migrate_forward("preferences", payload, from_version=1, to_version=1) is payload
+
+
+def test_migrate_forward_rejects_backwards() -> None:
+    with pytest.raises(ForwardMigrationFailed):
+        migrate_forward("preferences", {}, from_version=2, to_version=1)

--- a/tests/test_persisted_schema.py
+++ b/tests/test_persisted_schema.py
@@ -114,3 +114,36 @@ def test_sqlite_newer_version_rejected(tmp_path: Path) -> None:
             run_sqlite_migrations(conn, "audit")
     finally:
         conn.close()
+
+
+def test_audit_log_seeds_meta_row(tmp_path: Path) -> None:
+    from poor_cli.audit_log import AuditLogger
+
+    AuditLogger(audit_dir=tmp_path / "audit")
+    conn = sqlite3.connect(tmp_path / "audit" / "audit.db")
+    try:
+        assert read_sqlite_version(conn) == CURRENT_VERSIONS["audit"]
+        row = conn.execute("SELECT value FROM meta WHERE key='artifact'").fetchone()
+        assert row[0] == "audit"
+    finally:
+        conn.close()
+
+
+def test_session_store_writes_envelope(tmp_path: Path) -> None:
+    from poor_cli.session_store import SessionStore
+
+    store = SessionStore(repo_root=tmp_path)
+    store.save("abc", {"history": [{"role": "user", "content": "hi"}]})
+
+    index_raw = json.loads((tmp_path / ".poor-cli" / "sessions" / "index.json").read_text())
+    assert index_raw["schema_version"] == CURRENT_VERSIONS["session_index"]
+    assert index_raw["artifact"] == "session_index"
+
+    session_files = list((tmp_path / ".poor-cli" / "sessions").glob("session-abc-*.json"))
+    assert len(session_files) == 1
+    envelope = json.loads(session_files[0].read_text())
+    assert envelope["schema_version"] == CURRENT_VERSIONS["session"]
+    assert envelope["artifact"] == "session"
+
+    loaded = store.load_latest()
+    assert loaded is not None and loaded["session_id"] == "abc"

--- a/tests/test_persisted_schema.py
+++ b/tests/test_persisted_schema.py
@@ -1,0 +1,116 @@
+"""Tests for the persisted-state envelope and SQLite meta helpers (PRD 003)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from poor_cli.persisted import (
+    CURRENT_VERSIONS,
+    UnknownSchemaVersion,
+    load_json,
+    read_sqlite_version,
+    run_sqlite_migrations,
+    save_json,
+    seed_sqlite_meta,
+)
+
+
+def test_envelope_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "preferences.json"
+    payload = {"theme": "dark", "active_provider": "openai"}
+
+    save_json(path, "preferences", payload)
+
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == CURRENT_VERSIONS["preferences"]
+    assert on_disk["artifact"] == "preferences"
+    assert on_disk["data"] == payload
+
+    loaded = load_json(path, "preferences")
+    assert loaded == payload
+
+
+def test_save_json_rejects_unknown_artifact(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        save_json(tmp_path / "x.json", "not-a-real-artifact", {})
+
+
+def test_unknown_version_refuses_to_load(tmp_path: Path) -> None:
+    path = tmp_path / "preferences.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 9999,
+                "artifact": "preferences",
+                "data": {"theme": "dark"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnknownSchemaVersion):
+        load_json(path, "preferences")
+
+
+def test_load_json_missing_returns_default(tmp_path: Path) -> None:
+    sentinel = {"seeded": True}
+    assert load_json(tmp_path / "nope.json", "preferences", default=sentinel) is sentinel
+    assert load_json(tmp_path / "nope.json", "preferences") is None
+
+
+def test_sqlite_meta_table_seeded(tmp_path: Path) -> None:
+    db_path = tmp_path / "audit.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        seed_sqlite_meta(conn, "audit")
+        conn.commit()
+
+        cur = conn.execute("SELECT key, value FROM meta ORDER BY key")
+        rows = dict(cur.fetchall())
+        assert rows["schema_version"] == str(CURRENT_VERSIONS["audit"])
+        assert rows["artifact"] == "audit"
+        assert read_sqlite_version(conn) == CURRENT_VERSIONS["audit"]
+    finally:
+        conn.close()
+
+
+def test_seed_sqlite_meta_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "audit.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        seed_sqlite_meta(conn, "audit")
+        seed_sqlite_meta(conn, "audit")
+        conn.commit()
+        rows = conn.execute("SELECT COUNT(*) FROM meta").fetchone()
+        assert rows[0] == 2  # schema_version + artifact, not duplicated
+    finally:
+        conn.close()
+
+
+def test_run_sqlite_migrations_seeds_fresh_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "runs.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        run_sqlite_migrations(conn, "runs")
+        assert read_sqlite_version(conn) == CURRENT_VERSIONS["runs"]
+    finally:
+        conn.close()
+
+
+def test_sqlite_newer_version_rejected(tmp_path: Path) -> None:
+    from poor_cli.persisted.schema import set_sqlite_version
+
+    db_path = tmp_path / "audit.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        seed_sqlite_meta(conn, "audit")
+        set_sqlite_version(conn, CURRENT_VERSIONS["audit"] + 99)
+        conn.commit()
+        with pytest.raises(UnknownSchemaVersion):
+            run_sqlite_migrations(conn, "audit")
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- Adds `poor_cli/persisted/` with envelope-wrapped JSON I/O (`{schema_version, artifact, data}`), SQLite `meta`-table helpers, and a forward-only migration registry.
- Integrates the envelope into `session_store.py` and `checkpoint.py` JSON I/O paths.
- Seeds the `meta` table in `audit_log.py`, `automation_manager.py`, and `history.py` SQLite stores.
- Adds v0 auto-upgrade: files without the envelope are detected on load, migrated, and backed up to `.poor-cli/.legacy-v0/<name>.<timestamp>.bak`.

## PRD done-criteria
- [x] Every persisted JSON artifact in PRD scope (`session`, `session_index`, `checkpoint`) now writes `{schema_version, artifact, data}` on disk.
- [x] Every SQLite DB in PRD scope (`audit.db`, `automations.db`, `history.db`) has a `meta` table seeded with `schema_version` + `artifact`.
- [x] Loaders refuse unknown `schema_version` values with `UnknownSchemaVersion` (JSON + SQLite).
- [x] v0 auto-upgrade keeps a backup in `.poor-cli/.legacy-v0/`.
- [x] Tests cover migration chain ordering and missing-migration error path.

## Scope notes
- `config.py` uses YAML, not JSON — no JSON load/save paths exist there to route, so it was a no-op under the PRD's "narrow — only the load/save paths" constraint.
- `preferences.json` / `history.json` actually live in `repo_config.py`, which is not in PRD 003's listed files. Left untouched per PRD §9 boundary. Follow-up PRD can route those through `load_json` / `save_json` once scope is confirmed.
- SQLite migration registry is scaffolded but empty — per PRD §3 non-goals, actual SQLite migrations land with the PRDs that introduce schema changes.
- `history_migration_marker.json` is intentionally not deleted (PRD §5 Delete section: deferred to follow-up).

## Test plan
- [x] `pytest tests/test_persisted_schema.py tests/test_persisted_migrations.py` — 17/17 pass.
- [x] Full `pytest tests/` — 622 pass, 30 skipped. The one remaining failure (`test_product_contracts.py::…aiortc_pin`) predates this branch (reproducible on `main`; unrelated to persisted state).
- [x] `ruff check` on touched files — no new errors; net `-1` lint error vs. pre-branch state (removed two dangling `import json`s after the envelope migration made them unused).
- [ ] Manual: delete `.poor-cli/`, run `poor-cli exec --prompt "hi"`, verify envelope format in session index.

## Out of scope / not attempted
- `runs.db`, `repo_graph.db` — not owned by any file in the PRD file list. Their owning stores (`run_history.py`, `repo_graph.py`) can adopt `run_sqlite_migrations(conn, "runs")` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)